### PR TITLE
Audio Interface - WM8731 Audio Codec

### DIFF
--- a/c/audio.c
+++ b/c/audio.c
@@ -1,0 +1,192 @@
+#include <machine/spm.h>
+#include <stdio.h>
+#include "audio.h"
+
+/*
+* @file		Audio_setup.c
+* @author	Daniel Sanz Ausin s142290 & Fabian Goerge s150957
+* @brief	Setting up all the registers in the audio interface	
+*/
+
+/*
+* @brief		Writes the supplied data to the address register, 
+				sets the request signal and waits for the acknowledge signal. 
+* @param[in]	addr	the address of which register to write to. 
+						Has to be 7 bit long.
+* @param[in]	data	the data thats supposed to be written. 
+						Has to be 9 Bits long
+* @reutrn		returns 0 if successful and a negative number if there was an error. 
+*/
+int writeToI2C(char* addrC,char* dataC)
+{
+	int addr = 0;
+	int data = 0;
+
+	//Convert binary String of address to int
+	for(int i = 0; i < 7; i++)
+	{
+		addr *= 2;
+ 		if (*addrC++ == '1') addr += 1;
+	}
+
+	//Convert binary String of data to int
+	for(int i = 0; i < 9; i++)
+	{
+		data *= 2;
+ 		if (*dataC++ == '1') data += 1;
+	}
+
+	//Debug info:
+	printf("Sending Data: %i to adress %i\n",data,addr);
+
+	*i2cDataReg = data;
+	*i2cAdrReg	= addr;
+	*i2cReqReg	= 1;
+
+
+	while(*i2cAckReg == 0)
+	{ 
+		printf("Waiting ...\n");
+		//Maybe input something like a timeout ...
+	}
+	for (int i = 0; i<200; i++)  { *i2cReqReg=0; }
+
+	printf("success\n");
+	
+	return 0;
+	
+	
+
+}
+
+/*
+* @brief	Sets the default values
+*/
+void setup()
+{
+  /*
+  //----------Line in---------------------
+  char *addrLeftIn  = "0000000";		
+  char *dataLineIn  = "100010111";	//disable Mute, Enable Simultaneous Load, LinVol: 10111 - Set volume to 23 (of 31)										 
+  writeToI2C(addrLeftIn,dataLineIn);
+
+  char *addrRigthIn = "0000001";
+  writeToI2C(addrRigthIn,dataLineIn);
+  */
+  
+  //----------Headphones---------------------
+  char *addrLeftHead  = "0000010";	
+  char *dataHeadphone = "001111001";	// disable simultaneous loads, zero cross disable, LinVol: 1111001 (0db)	
+  writeToI2C(addrLeftHead,dataHeadphone);
+
+  char *addrRightHead = "0000011";		
+  writeToI2C(addrRightHead,dataHeadphone);
+
+  //--------Analogue Audio Path Control-----
+  char *addrAnalogue  = "0000100";	
+  char *dataAnalogue = "000010010"; //DAC selected, rest disabled, MIC muted, Line input select to ADC
+  writeToI2C(addrAnalogue,dataAnalogue);
+
+  
+  //--------Digital Audio Path Control-----
+  char *addrDigital  = "0000101";	
+  char *dataDigital  = "000000000";	//enable soft mute and disable de-emphasis, enable highpass filter
+  writeToI2C(addrDigital,dataDigital);
+  
+  
+  //---------Digital Audio Interface Format---------
+  char *addrInterface  = "0000111";	
+  char *dataInterface = "000010011"; //BCLK not inverted, slave, right-channel-right-data, LRP = A mode for DSP, 16-bit audio, DSP mode	
+  writeToI2C(addrInterface,dataInterface);
+  
+  
+  //--------Sampling Control----------------
+  char *addrSample  = "0001000";	
+  char *dataSample  = "000000000"; //USB mode, BOSR=1, Sample Rate = 44.1 kHz both for ADC and DAC	
+  writeToI2C(addrSample,dataSample);
+
+  printf("FINISHED SETUP!\n");
+}
+
+
+/*
+* @brief		Writes the supplied data to the audio interface using the correct protocoll. 
+* @param[in]	l	left audio data. Has to be <= 16 Bit. 
+* @param[in]	r	right audio data. Has to be <= 16 Bit.  
+* @reutrn		returns 0 if successful and a negative number if there was an error. 
+*/
+int setOutputAudio(short l, short r)
+{
+	*audioDacLReg = l;
+	*audioDacRReg = r;
+	return 0;
+}
+
+/*
+* @brief		this will put the audio from the registers into the value of l and r
+* @param[in]	l	here the left audio data will be stored. Has to be <= 16 Bit. 
+* @param[in]	r	here the right audio data will be stored. Has to be <= 16 Bit.  
+* @reutrn		returns 0 if successful and a negative number if there was an error. 
+*/
+int getInputAudio(short *l, short *r)
+{
+	*l = *audioAdcLReg;
+	*r = *audioAdcRReg;
+	return 0;
+}
+
+/*
+* @brief		It synchroizes with dac the sampling frequency by waiting for the LRC signal to go from low to high. 
+*/
+void waitSyncDac()
+{
+		while (*audioDacLrcReg == 0);
+		while (*audioDacLrcReg == 1);
+}
+
+/*
+* @brief		It synchroizes with the adc sampling frequency by waiting for the LRC signal to go from low to high. 
+*/
+void waitSyncAdc()
+{
+		while (*audioAdcLrcReg == 0);
+		while (*audioAdcLrcReg == 1);
+}
+
+/*
+* @brief		changes the volume of the audio output. 
+* @param[in]	vol 	in db. Has to be between +6 and -73
+* @reutrn		returns 0 if successful and a negative number if there was an error. 
+*/
+int changeVolume(int vol)
+{
+	//127--1111111 = +6dB	
+	//121--1111001 = 0 dB
+	//48--0110000 = -73dB							
+  if ((vol<-73) || (vol>6)) {
+    return -1;	//Invalid input.
+  }
+
+	//Since both Left Channel Zero Cross detect and simultaneous Load are disabled this can be send imideatly:
+	//LEFT:
+	*i2cDataReg = vol + 121;
+	*i2cAdrReg	 = 2;
+	*i2cReqReg	 = 1;
+	while(*i2cAckReg == 0);
+	for (int i = 0; i<200; i++)  { *i2cReqReg=0; }
+	
+	//RIGHT:
+	*i2cDataReg = vol + 121;
+	*i2cAdrReg	 = 3;
+	*i2cReqReg	 = 1;
+	while(*i2cAckReg == 0);
+	for (int i = 0; i<200; i++)  { *i2cReqReg=0; }
+
+	return 0;
+}
+
+
+
+
+
+

--- a/c/audio.h
+++ b/c/audio.h
@@ -1,0 +1,43 @@
+#ifndef AUDIO_H
+#define AUDIO_H
+
+//Leds
+volatile _SPM int *ledReg				= (volatile _SPM int *) 0xF0090000;
+
+//Keys
+volatile _SPM int *keyReg				= (volatile _SPM int *) 0xF00A0000;
+
+//DAC
+volatile _SPM int *audioDacLReg			= (volatile _SPM int *) 0xF00B0000;
+volatile _SPM int *audioDacRReg 		= (volatile _SPM int *) 0xF00B0010;
+volatile _SPM int *audioDacEnReg 		= (volatile _SPM int *) 0xF00B0020;
+volatile _SPM int *audioDacBusyReg		= (volatile _SPM int *) 0xF00B0030;
+volatile _SPM int *audioDacReqReg		= (volatile _SPM int *) 0xF00B0040;
+volatile _SPM int *audioDacLrcReg		= (volatile _SPM int *) 0xF00B0050;
+
+//ADC
+volatile _SPM int *audioAdcLReg			= (volatile _SPM int *) 0xF00B0060;
+volatile _SPM int *audioAdcRReg			= (volatile _SPM int *) 0xF00B0070;
+volatile _SPM int *audioAdcEnReg		= (volatile _SPM int *) 0xF00B0080;
+volatile _SPM int *audioAdcBusyReg		= (volatile _SPM int *) 0xF00B0090;
+volatile _SPM int *audioAdcReqReg		= (volatile _SPM int *) 0xF00B00A0;
+volatile _SPM int *audioAdcLrcReg		= (volatile _SPM int *) 0xF00B00B0;
+
+//I2C
+volatile _SPM int *i2cDataReg 			= (volatile _SPM int *) 0xF00B00C0;
+volatile _SPM int *i2cAdrReg 			= (volatile _SPM int *) 0xF00B00D0;
+volatile _SPM int *i2cAckReg			= (volatile _SPM int *) 0xF00B00E0;
+volatile _SPM int *i2cReqReg			= (volatile _SPM int *) 0xF00B00F0;
+
+
+int 	writeToI2C(char* addrC,char* dataC);
+void 	setup();
+int 	setOutputAudio(short l, short r);
+int 	getInputAudio(short *l, short *r);
+int 	changeVolume(int vol);
+void 	waitSyncDac();
+void 	waitSyncAdc();
+
+
+
+#endif

--- a/c/audio_delay.c
+++ b/c/audio_delay.c
@@ -1,0 +1,120 @@
+#include <machine/spm.h>
+#include <machine/rtc.h>
+#include <stdio.h>
+#include "audio.h"
+#include "audio.c"
+
+
+
+/*
+* @file		Audio_Demo.c
+* @author	Daniel Sanz Ausin s142290 & Fabian Goerge s150957
+* @brief	Presentation demo.	
+*/
+
+short audioBufferL[52080] = {0}; //1 s maximum delay
+short audioBufferR[52080] = {0}; //1 s maximum delay
+int delayTime = 13020; // 250 ms
+
+
+int main() {
+	
+	setup();
+
+ 
+	short inL = 0;
+	short inR = 0;
+	*audioDacEnReg = 1;
+	*audioAdcEnReg = 1;
+	int length = sizeof(audioBufferL) / sizeof(short)-1;
+	int delayPosition = 0;
+	int p = 0;
+	int delayLim = delayTime - 1;
+	int currentKey = 0;
+	int volume = 0;
+	int volumeResult;
+
+	while(*keyReg != 3)
+	{
+	  
+	  switch(*keyReg) {
+	  case 14:
+	    if (currentKey != 14) {
+	      currentKey = 14;
+	      volume ++;
+	      volumeResult = changeVolume(volume);
+	      if(volumeResult == -1) {
+		volume--;
+		printf("Volume already at max: %i dB\n", volume);
+	      }
+	      else {
+		printf("Volume %i dB\n", volume);
+	      }
+	    }
+	    break;
+	  case 13:
+	    if (currentKey != 13) {
+	      currentKey = 13;
+	      volume--;
+	      volumeResult = changeVolume(volume);
+	      if(volumeResult == -1) {
+		volume++;
+		printf("Volume already at min: %i dB\n", volume);
+	      }
+	      else {
+		printf("Volume %i dB\n", volume);
+	      }
+	    }
+	    break;
+	  case 6:
+	    if (currentKey != 6) {
+	      currentKey = 6;
+	      delayTime = delayTime * 2;
+	      if (delayTime > length) {
+		delayTime = length;
+		printf("Delay alreay at max: %i\n", delayTime);
+	      }
+	      else {
+		printf("Delay samples: %i\n", delayTime);
+	      }
+			delayLim = delayTime - 1;
+	    }
+	    break;
+	  case 5:
+	    if (currentKey != 5) {
+	      currentKey = 5;
+	      if (delayTime > 1) {
+		delayTime = (int)(delayTime/2);
+		printf("Delay samples: %i\n", delayTime);
+	      }
+	      else {
+		printf("Delay alreay at min: %i\n", delayTime);
+	      }
+			delayLim = delayTime - 1;
+	    }
+	    break;
+	  default:			
+		waitSyncDac();
+	    currentKey = 0;
+	    if(p >= delayTime) {
+	      p=0;
+	    }
+	    getInputAudio(&inL,&inR);
+	    if(p == delayLim) {
+	      delayPosition = 0;
+	    }
+	    else {
+	      delayPosition = p + 1;
+	    }
+	    //delayPosition = (p+1)%delayTime;			
+	    audioBufferL[p] = inL + (short)(audioBufferL[delayPosition] >> 2);
+		audioBufferR[p] = inR + (short)(audioBufferR[delayPosition] >> 2);
+	    setOutputAudio(audioBufferL[p],audioBufferR[p]);	
+	    p++;
+	  }
+	}
+	return 0;
+}
+
+
+

--- a/c/audio_i2c_test.c
+++ b/c/audio_i2c_test.c
@@ -1,0 +1,65 @@
+#include <machine/spm.h>
+#include <stdio.h>
+#include "audio.h"
+
+/*
+* @file		control_reg_test.c
+* @author	Daniel Sanz Ausin s142290 & Fabian Goerge s150957
+* @brief	Testing I2C interface to write into WM8731 configuration registers	
+*/
+
+
+/*
+* @brief		Writes the supplied data to the address register, 
+				sets the request signal and waits for the acknowledge signal. 
+* @param[in]	addr	the address of which register to write to. 
+						Has to be 7 bit long.
+* @param[in]	data	the data thats supposed to be written. 
+						Has to be 9 Bits long
+* @reutrn		returns 0 if successful and a negative number if there was an error. 
+*/
+int writeToI2C2(int addr,int data) {
+
+
+	//temporary
+	volatile _SPM int *i2cWrReg	= (volatile _SPM int *) 0xF00B00B0;
+	volatile _SPM int *i2cSDIN	= (volatile _SPM int *) 0xF00B00C0;
+
+	*i2cDataReg  = data;
+	*i2cAdrReg = addr;
+	*i2cReqReg = 1;
+
+	while (*i2cAckReg == 0) {
+	
+		if (*i2cWrReg == 0) {
+			*i2cSDIN = '0';
+		}
+		else {
+			*i2cSDIN = '1';
+		}
+	}
+	*i2cReqReg = 0;
+	
+	printf("Success ...\n");
+
+	return 0;
+}
+
+int main() {
+	
+	printf("starting...\n");
+
+	int addr = 123;
+	int data = 444;
+
+	printf("gonna write %d into %d\n", data, addr);
+	writeToI2C2(addr, data);
+
+	addr = 0;
+	data = 12;
+
+	printf("gonna write %d into %d\n", data, addr);
+	writeToI2C2(addr, data);
+	
+	return 0;
+}

--- a/c/audio_inout.c
+++ b/c/audio_inout.c
@@ -1,0 +1,30 @@
+#include <machine/spm.h>
+#include <stdio.h>
+#include "audio.h"
+#include "audio.c"
+
+/*
+* @file		Audio_InOut.c
+* @author	Daniel Sanz Ausin s142290 & Fabian Goerge s150957
+* @brief	This program takes the input auido data and outputs it again
+*/
+
+int main() {
+	setup();
+
+	short inL = 0;
+	short inR = 0;
+	*audioDacEnReg = 1;
+	*audioAdcEnReg = 1;
+
+	while(*keyReg != 3)
+	{
+		getInputAudio(&inL,&inR);
+		//printf("InL: %i InR: %i\n",inL,inR);
+		setOutputAudio(inL,inR);
+	}
+	return 0;
+}
+
+
+

--- a/c/audio_regrw_test.c
+++ b/c/audio_regrw_test.c
@@ -1,0 +1,56 @@
+#include <machine/spm.h>
+#include <stdio.h>
+#include "audio.h"
+
+/*
+* @file		Audio_regReadWrite_test.c
+* @author	Daniel Sanz Ausin s142290 & Fabian Goerge s150957
+* @brief	Testing whether in every register it can be written and read from. */
+
+
+int main() {
+	printf("Testprogram for the audio interface!\n");
+
+	// Test program
+	
+	int loopNumber =0;
+	for (int i = 0; i < 2; i++)
+	{
+		printf("Audio DAC L:\t%i\n"		,*audioDacLReg);
+		printf("Audio DAC R:\t%i\n"		,*audioDacRReg);
+		printf("Audio DAC Enable:\t%i\n",*audioDacEnReg);
+		printf("Audio DAC Busy:\t%i\n"	,*audioDacBusyReg);
+		printf("Audio DAC Req:\t%i\n"	,*audioDacReqReg);
+		printf("Audio LRC :\t%i\n"		,*audioDacLrcReg);
+
+		printf("Audio ADC L :\t%i\n"	,*audioAdcLReg);
+		printf("Audio ADC R :\t%i\n"	,*audioAdcRReg);
+		printf("Audio ADC Enable:\t%i\n",*audioAdcEnReg);
+		printf("Audio ADC Busy:\t%i\n"	,*audioAdcBusyReg);
+		printf("Audio ADC Req:\t%i\n"	,*audioAdcReqReg);
+		printf("Audio LRC:\t%i\n"		,*audioAdcLrcReg);
+
+		printf("I2C Data:\t%i\n"	,*i2cDataReg);
+		printf("I2C Adr:\t%i\n"		,*i2cAdrReg);
+		printf("I2C Ack:\t%i\n"		,*i2cAckReg);
+		printf("I2C Req:\t%i\n"		,*i2cReqReg);
+
+		*audioDacLReg 	=	1111;
+		*audioDacRReg 	=	2222;
+		*audioDacEnReg 	= 	1;
+		*audioDacReqReg 	=	1;
+
+		*audioAdcEnReg	= 1;
+		*audioAdcReqReg = 1;
+
+		*i2cDataReg 	=	333;
+		*i2cAdrReg 	=	44;	
+		*i2cReqReg 	=	1;
+		printf("Changed values ...\n\n");
+	}
+
+    return 0;
+}
+
+
+

--- a/c/audio_sin.c
+++ b/c/audio_sin.c
@@ -1,0 +1,99 @@
+#include <machine/spm.h>
+#include <machine/rtc.h>
+#include <stdio.h>
+#include <math.h>
+#include "audio.h"
+#include "audio.c"
+
+
+/*
+* @file		Audio_FirstSound.c
+* @author	Daniel Sanz Ausin s142290 & Fabian Goerge s150957
+* @brief	Setting up all the registers in the audio interface	
+*/
+
+int sineArray[220];
+
+
+int cyclesStart = 0;
+int nbrCycles = 0;
+int sampleFreq = 1536; //256*6
+
+
+/*
+* @brief		Writes the supplied data to the address register, 
+				sets the request signal and waits for the acknowledge signal. 
+* @param[in]	addr	the address of which register to write to. 
+						Has to be 7 bit long.
+* @param[in]	data	the data thats supposed to be written. 
+						Has to be 9 Bits long
+* @reutrn		returns 0 if successful and a negative number if there was an error. 
+*/
+
+
+void playSine()
+{
+	//Fill sine array:
+	for (int i = 0; i < 220; i++)
+	{
+		sineArray[i] = 16384*sin(2.0*M_PI* i /220);
+		printf("Sine: %i\n",sineArray[i]);
+	}
+
+	for ( int j = 0; j < 600 ; j++)
+	{
+		for (int i = 0; i < 220; i++)
+		{
+			waitSyncDac();
+			setOutputAudio(sineArray[i],sineArray[i]);
+		}
+	}
+
+}
+
+
+int main() {
+
+  printf("CPU frequency: %d MHz\n", get_cpu_freq()/1000000);
+
+	setup();
+	*audioDacEnReg = 1;
+	cyclesStart	= get_cpu_cycles();
+	playSine();
+	playSine();
+//	playSine();
+//	playSine();
+//	playSine();
+//	playSine();
+ 
+
+	
+/*
+ //Simple sound:
+  int counter = 0;
+  int counter2 = 0;
+  *audioDacEnReg = 1;
+  while (counter2 < 400)
+    {
+      counter = 0;
+      while(counter < 220)	{ 	
+	setOutputAudio(11241,23456);
+	counter++; 
+      }
+break;
+      counter = 0;	
+      //if (counter % 20 == 0) printf("Hi %i\n",counter2);	
+      while(counter < 220)	{ 
+	setOutputAudio(0,0);	
+	counter++; 
+      }
+      counter2++;
+    }
+ 
+*/
+
+  return 0;
+}
+
+
+

--- a/hardware/config/altde2-115-audio.xml
+++ b/hardware/config/altde2-115-audio.xml
@@ -1,0 +1,47 @@
+<patmos default="default.xml">
+  <description>default configuration for DE2-115 board</description>
+
+  <frequency Hz="80000000"/>
+
+  <ExtMem size="2M" DevTypeRef="Sram16" />
+
+  <IOs>
+	<IO DevTypeRef="Uart" offset="8"/>
+	<IO DevTypeRef="Leds" offset="9"/>
+	<IO DevTypeRef="Keys" offset="10" intrs="2,3,4,5"/>
+	<IO DevTypeRef="audio_interface" offset="11"/> 
+  </IOs>
+
+  <Devs>
+  	<Dev DevType="Uart" entity="Uart" iface="OcpCore">
+  	  <params>
+  		<param name="baudRate" value="115200"/>
+  		<param name="fifoDepth" value="16"/>
+  	  </params>
+  	</Dev>
+  	<Dev DevType="Leds" entity="Leds" iface="OcpCore">
+  	  <params>
+  		<param name="ledCount" value="9"/>
+  	  </params>
+  	</Dev>
+  	<Dev DevType="Keys" entity="Keys" iface="OcpCore">
+  	  <params>
+  		<param name="keyCount" value="4"/>
+  	  </params>
+  	</Dev>
+    <Dev DevType="Sram16" entity="SRamCtrl" iface="OcpBurst">
+        <params>
+            <param name="ocpAddrWidth" value="21" />
+            <param name="sramAddrWidth" value="20" />
+            <param name="sramDataWidth" value="16" />
+        </params>
+    </Dev>
+	<Dev DevType="audio_interface" entity="audio_interface" iface="OcpCore">
+		<params>
+			<param name="audioLength"		value="16"/>  <!-- either 16, 20, 24 or 32 -->
+			<param name="audioFsDivider"	value="256"/> <!-- depending on chosen Fs (see datasheet) -->
+			<param name="audioClkDivider"	value="6"/>   <!-- for the bclk/xlk: patmosclk / audioClkDivider-->
+		</params>
+	</Dev> 
+  </Devs>
+</patmos>

--- a/hardware/quartus/altde2-115-audio/patmos-audio.qsf
+++ b/hardware/quartus/altde2-115-audio/patmos-audio.qsf
@@ -1,0 +1,209 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 1991-2011 Altera Corporation
+# Your use of Altera Corporation's design tools, logic functions
+# and other software and tools, and its AMPP partner logic
+# functions, and any output files from any of the foregoing
+# (including device programming or simulation files), and any
+# associated documentation or information are expressly subject
+# to the terms and conditions of the Altera Program License
+# Subscription Agreement, Altera MegaCore Function License
+# Agreement, or other applicable license agreement, including,
+# without limitation, that your use is for the sole purpose of
+# programming logic devices manufactured by Altera and sold by
+# Altera or its authorized distributors.  Please refer to the
+# applicable agreement for further details.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus II
+# Version 11.0 Build 208 07/03/2011 Service Pack 1 SJ Web Edition
+# Date created = 11:11:57  June 19, 2012
+#
+# -------------------------------------------------------------------------- #
+#
+# Notes:
+#
+# 1) The default values for assignments are stored in the file:
+#		patmos_core_assignment_defaults.qdf
+#    If this file doesn't exist, see file:
+#		assignment_defaults.qdf
+#
+# 2) Altera recommends that you do not modify this file. This
+#    file is updated automatically by the Quartus II software
+#    and any changes you make may be lost or overwritten.
+#
+# -------------------------------------------------------------------------- #
+
+
+set_global_assignment -name FAMILY "Cyclone IV E"
+set_global_assignment -name DEVICE EP4CE115F29C7
+set_global_assignment -name TOP_LEVEL_ENTITY patmos_top
+set_global_assignment -name ORIGINAL_QUARTUS_VERSION "11.0 SP1"
+set_global_assignment -name PROJECT_CREATION_TIME_DATE "11:11:57  JUNE 19, 2012"
+set_global_assignment -name LAST_QUARTUS_VERSION 14.0
+
+
+set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
+set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85
+set_global_assignment -name ERROR_CHECK_FREQUENCY_DIVISOR 1
+set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
+set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
+set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
+set_global_assignment -name USE_CONFIGURATION_DEVICE ON
+set_global_assignment -name RESERVE_ALL_UNUSED_PINS "AS INPUT TRI-STATED"
+set_global_assignment -name STRATIX_DEVICE_IO_STANDARD "3.3-V LVCMOS"
+
+
+
+set_global_assignment -name RESERVE_ALL_UNUSED_PINS_NO_OUTPUT_GND "AS INPUT TRI-STATED"
+
+set_location_assignment PIN_Y2 -to clk
+set_location_assignment PIN_T8 -to oSRAM_A[19]
+set_location_assignment PIN_AB8 -to oSRAM_A[18]
+set_location_assignment PIN_AB9 -to oSRAM_A[17]
+set_location_assignment PIN_AC11 -to oSRAM_A[16]
+set_location_assignment PIN_AB11 -to oSRAM_A[15]
+set_location_assignment PIN_AA4 -to oSRAM_A[14]
+set_location_assignment PIN_AC3 -to oSRAM_A[13]
+set_location_assignment PIN_AB4 -to oSRAM_A[12]
+set_location_assignment PIN_AD3 -to oSRAM_A[11]
+set_location_assignment PIN_AF2 -to oSRAM_A[10]
+set_location_assignment PIN_T7 -to oSRAM_A[9]
+set_location_assignment PIN_AF5 -to oSRAM_A[8]
+set_location_assignment PIN_AC5 -to oSRAM_A[7]
+set_location_assignment PIN_AB5 -to oSRAM_A[6]
+set_location_assignment PIN_AE6 -to oSRAM_A[5]
+set_location_assignment PIN_AB6 -to oSRAM_A[4]
+set_location_assignment PIN_AC7 -to oSRAM_A[3]
+set_location_assignment PIN_AE7 -to oSRAM_A[2]
+set_location_assignment PIN_AD7 -to oSRAM_A[1]
+set_location_assignment PIN_AB7 -to oSRAM_A[0]
+set_location_assignment PIN_AD5 -to oSRAM_OE_N
+set_location_assignment PIN_AE8 -to oSRAM_WE_N
+set_location_assignment PIN_AF8 -to oSRAM_CE_N
+set_location_assignment PIN_AD4 -to oSRAM_LB_N
+set_location_assignment PIN_AC4 -to oSRAM_UB_N
+set_location_assignment PIN_AG3 -to SRAM_DQ[15]
+set_location_assignment PIN_AF3 -to SRAM_DQ[14]
+set_location_assignment PIN_AE4 -to SRAM_DQ[13]
+set_location_assignment PIN_AE3 -to SRAM_DQ[12]
+set_location_assignment PIN_AE1 -to SRAM_DQ[11]
+set_location_assignment PIN_AE2 -to SRAM_DQ[10]
+set_location_assignment PIN_AD2 -to SRAM_DQ[9]
+set_location_assignment PIN_AD1 -to SRAM_DQ[8]
+set_location_assignment PIN_AF7 -to SRAM_DQ[7]
+set_location_assignment PIN_AH6 -to SRAM_DQ[6]
+set_location_assignment PIN_AG6 -to SRAM_DQ[5]
+set_location_assignment PIN_AF6 -to SRAM_DQ[4]
+set_location_assignment PIN_AH4 -to SRAM_DQ[3]
+set_location_assignment PIN_AG4 -to SRAM_DQ[2]
+set_location_assignment PIN_AF4 -to SRAM_DQ[1]
+set_location_assignment PIN_AH3 -to SRAM_DQ[0]
+set_location_assignment PIN_G12 -to iUartPins_rxd
+set_location_assignment PIN_G9 -to oUartPins_txd
+set_location_assignment PIN_F17 -to oLedsPins_led[8]
+set_location_assignment PIN_G21 -to oLedsPins_led[7]
+set_location_assignment PIN_G22 -to oLedsPins_led[6]
+set_location_assignment PIN_G20 -to oLedsPins_led[5]
+set_location_assignment PIN_H21 -to oLedsPins_led[4]
+set_location_assignment PIN_E24 -to oLedsPins_led[3]
+set_location_assignment PIN_E25 -to oLedsPins_led[2]
+set_location_assignment PIN_E22 -to oLedsPins_led[1]
+set_location_assignment PIN_E21 -to oLedsPins_led[0]
+set_location_assignment PIN_R24 -to iKeysPins_key[3]
+set_location_assignment PIN_N21 -to iKeysPins_key[2]
+set_location_assignment PIN_M21 -to iKeysPins_key[1]
+set_location_assignment PIN_M23 -to iKeysPins_key[0]
+set_location_assignment PIN_D1 -to oAudio_dacDat
+set_location_assignment PIN_E3 -to oAudio_dacLrc
+set_location_assignment PIN_D2 -to iAudio_adcDat
+set_location_assignment PIN_C2 -to oAudio_adcLrc
+set_location_assignment PIN_A8 -to ioAudio_sdat
+set_location_assignment PIN_B7 -to oAudio_sclk
+set_location_assignment PIN_F2 -to oAudio_bclk
+set_location_assignment PIN_E1 -to oAudio_xclk
+
+
+set_global_assignment -name SYNTH_TIMING_DRIVEN_SYNTHESIS ON
+set_global_assignment -name CYCLONEII_OPTIMIZATION_TECHNIQUE SPEED
+set_global_assignment -name POWER_PRESET_COOLING_SOLUTION "23 MM HEAT SINK WITH 200 LFPM AIRFLOW"
+set_global_assignment -name POWER_BOARD_THERMAL_MODEL "NONE (CONSERVATIVE)"
+set_global_assignment -name DEVICE_FILTER_PACKAGE FBGA
+set_global_assignment -name VHDL_FILE "../../vhdl/patmos_de2-115.vhdl"
+set_global_assignment -name VHDL_FILE ../../vhdl/altera/cyc2_pll.vhd
+set_global_assignment -name VERILOG_FILE ../../build/Patmos.v
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_WE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_CE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_LB_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_OE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_UB_N
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oUartPins_txd
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to iUartPins_rxd
+set_instance_assignment -name IO_STANDARD "2.5 V" -to iKeysPins_key[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to iKeysPins_key[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to iKeysPins_key[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to iKeysPins_key[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|addrReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|doutReg"
+set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|doutEnaReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|noeReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|nweReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|nlbReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|nubReg"
+set_global_assignment -name FITTER_EFFORT "STANDARD FIT"
+set_global_assignment -name OPTIMIZE_HOLD_TIMING "ALL PATHS"
+set_global_assignment -name OPTIMIZE_MULTI_CORNER_TIMING ON
+set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC ON
+set_global_assignment -name SEED 6
+set_global_assignment -name VERILOG_MACRO "SYNTHESIS=<None>"
+
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/hardware/src/io/audio_adc.scala
+++ b/hardware/src/io/audio_adc.scala
@@ -1,0 +1,146 @@
+// ADC converter for WM8731 audio codec.
+// receives audio data from WM8731 and stores it into audio_l_o and audio_r_o registers
+// converts every time enable signal is set to high
+// sets busy to high while converting: during (1 + AUDIO_BITLENGTH*2) cycles of BCLK
+
+package io
+
+import Chisel._
+
+class audio_adc(AUDIO_BITLENGTH: Int, FS_DIV: Int) extends Module 
+{
+	//constants: from CONFIG parameters
+	//val AUDIO_BITLENGTH = 16;
+	//val FS_DIV = 256;
+	
+	//IOs
+	val io = new Bundle 
+	{
+		//to/from PATMOS
+		val audio_l_o = UInt(OUTPUT, AUDIO_BITLENGTH)
+		val audio_r_o = UInt(OUTPUT, AUDIO_BITLENGTH)
+		val en_adc_i = Bool(dir = INPUT) //enable signal
+		val busy_o = UInt(OUTPUT, 1)
+		//from audio_clk_gen 
+		val BCLK_i = UInt(INPUT, 1)
+		//to/from WM8731
+		val ADCLRC_o = UInt(OUTPUT, 1)
+		val ADCDAT_i = UInt(INPUT, 1)
+	}
+
+	//Counter for audio sampling
+	val Fs_CYCLES = UInt(FS_DIV-1);
+	val Fs_cntReg = Reg(init = UInt(0, 9)) //counter register for Fs
+
+	val audio_cntReg = Reg(init = UInt(0, 5)) //counter register for Audio bits: max 32 bits: 5 bit counter
+
+	//states
+	val s_idle :: s_start_1 :: s_start_2 :: s_left :: s_right :: Nil = Enum(UInt(), 5)
+	//state register
+	val state = Reg(init = s_idle)
+
+	//Registers for outputs:
+	val ADCLRC_reg = Reg(init = UInt(0, 1))
+	val busy_reg = Reg(init = UInt(0, 1))
+	//assign to inputs/uputs
+	io.ADCLRC_o 	:= ADCLRC_reg
+	io.busy_o 	:= busy_reg
+
+	//register for BCLK_i
+	val BCLK_reg = Reg(init = UInt(0, 1))
+	BCLK_reg := io.BCLK_i
+
+	//registers for audio data
+	val audio_l_reg = Reg(init = UInt(0, AUDIO_BITLENGTH))
+	val audio_r_reg = Reg(init = UInt(0, AUDIO_BITLENGTH))
+	val audio_l_reg_o = Reg(init = UInt(0, AUDIO_BITLENGTH))
+	val audio_r_reg_o = Reg(init = UInt(0, AUDIO_BITLENGTH))
+	//connect registers to ouputs when conversion is not busy
+	io.audio_l_o := audio_l_reg_o
+	io.audio_r_o := audio_r_reg_o
+	when(busy_reg === UInt(0)) {
+		audio_l_reg_o := audio_l_reg
+		audio_r_reg_o := audio_r_reg
+	}
+
+	//conversion when enabled
+	when (io.en_adc_i === UInt(1)) {
+
+		//state machine: on falling edge of BCLK for idle, start and wait
+		when( (io.BCLK_i =/= BCLK_reg) && (io.BCLK_i === UInt(0)) ) {
+
+			//counter for audio sampling
+			Fs_cntReg := Fs_cntReg + UInt(1)
+			when(Fs_cntReg === Fs_CYCLES) {
+				Fs_cntReg := UInt(0) //reset to 0
+			}
+			//FSM for audio conversion
+			switch (state) {
+				is (s_idle) 
+				{
+					ADCLRC_reg := UInt(0)
+					busy_reg := UInt(0)
+					when (Fs_cntReg === UInt(0)) 
+					{ 
+						state := s_start_1 
+					}
+				}
+				is (s_start_1) 
+				{
+					ADCLRC_reg := UInt(1)
+					busy_reg := UInt(1)
+					state := s_start_2 //directly jump to next state
+				}
+				is (s_start_2)
+				{
+					busy_reg := UInt(1)
+					ADCLRC_reg := UInt(0) //lrclk low already
+					state := s_left //directly jump to next state
+				}
+			}
+		}
+
+		//state machine: on raising edge of BCLK for left and right
+		.elsewhen( (io.BCLK_i =/= BCLK_reg) && (io.BCLK_i === UInt(1)) ) {
+			//FSM for audio conversion
+			switch (state) {
+				is (s_left) 
+				{
+					busy_reg := UInt(1)
+					audio_l_reg(UInt(AUDIO_BITLENGTH) - audio_cntReg - UInt(1)) := io.ADCDAT_i
+					when (audio_cntReg < UInt(AUDIO_BITLENGTH-1)) 
+					{
+						audio_cntReg := audio_cntReg + UInt(1)
+					}
+					.otherwise //bit AUDIO_BITLENGTH-1
+					{ 
+		   				audio_cntReg := UInt(0) //restart counter
+						state := s_right
+					}
+				}
+				is (s_right) 
+				{
+					busy_reg := UInt(1)
+					audio_r_reg(UInt(AUDIO_BITLENGTH) - audio_cntReg - UInt(1)) := io.ADCDAT_i
+					when (audio_cntReg < UInt(AUDIO_BITLENGTH-1)) 
+					{
+						audio_cntReg := audio_cntReg + UInt(1)
+					}
+					.otherwise 	 //bit AUDIO_BITLENGTH-1
+					{
+						audio_cntReg := UInt(0) //restart counter
+						state := s_idle
+					}
+				}	
+			}
+		}
+	}
+	.otherwise {//when not enable
+		state := s_idle
+		Fs_cntReg := UInt(0)
+		audio_cntReg := UInt(0)
+		busy_reg := UInt(0)
+		ADCLRC_reg := UInt(0)
+	}
+}
+

--- a/hardware/src/io/audio_clk_gen.scala
+++ b/hardware/src/io/audio_clk_gen.scala
@@ -1,0 +1,53 @@
+// BCLK & XCLK generator for WM8731 audio codec.
+// BCLK & XCLK run at F = Patmos_freq/clkDivider_i
+//currently clkDivider = 6,  F = 13.33 MHz (patmos 80 MHz)
+
+package io
+
+import Chisel._
+
+class audio_clk_gen(CLK_DIV: Int) extends Module
+{
+	//constants: from CONFIG parameters
+	//val CLK_DIV = 6;
+
+	//IOs
+	val io = new Bundle 
+	{
+		//inputs from PATMOS
+		val en_adc_i = UInt(INPUT, 1)
+		val en_dac_i = UInt(INPUT, 1)
+		//outputs to WM8731	
+		val BCLK_o = UInt(OUTPUT, 1)
+		val XCLK_o = UInt(OUTPUT, 1)
+	}
+
+	//register containing divider value
+	val clk_lim_reg = Reg(init = UInt(6, 5)) //5 bits, initialized to 6
+	clk_lim_reg := UInt(CLK_DIV/2) //get from params!
+
+	//Counter: clock divider for BCLK and XCLK
+	val clk_cnt_reg = Reg(init = UInt(0, 5)) //counter reg for BCLK and XCLK
+
+	//registers for XCLK and BCLK
+	val CLK_reg = Reg(init = UInt(0, 1))
+
+	//connect outputs
+	io.BCLK_o := CLK_reg
+	io.XCLK_o := CLK_reg
+
+	//count for CLK only when any enable signal is high
+	when( (io.en_adc_i === UInt(1)) || (io.en_dac_i === UInt(1)) ) {		
+		when( clk_cnt_reg === clk_lim_reg - UInt(1)) {
+			clk_cnt_reg := UInt(0)
+			CLK_reg := ~CLK_reg
+		}
+		.otherwise {
+			clk_cnt_reg := clk_cnt_reg + UInt(1)
+		}
+	}
+	.otherwise {
+		clk_cnt_reg := UInt(0)
+		CLK_reg := UInt(0)
+	}
+}

--- a/hardware/src/io/audio_dac.scala
+++ b/hardware/src/io/audio_dac.scala
@@ -1,0 +1,138 @@
+// DAC converter for WM8731 audio codec.
+// receives audio data into audio_l_i and audio_r_i registers
+// converts every time enable signal is set to high
+// sets busy to high while converting: during (1 + AUDIO_BITLENGTH*2) cycles of BCLK
+
+package io
+
+import Chisel._
+
+class audio_dac(AUDIO_BITLENGTH: Int, FS_DIV: Int) extends Module 
+{
+	//constants: from CONFIG parameters
+	//val AUDIO_BITLENGTH = 16;
+	//val FS_DIV = 256;
+
+	//IOs
+	val io = new Bundle 
+	{
+		//inputs from PATMOS
+		val audio_l_i = UInt(INPUT, AUDIO_BITLENGTH)
+		val audio_r_i = UInt(INPUT, AUDIO_BITLENGTH)
+		val en_dac_i = Bool(dir = INPUT) //enable signal
+		//from audio_clk_gen 
+		val BCLK_i = UInt(INPUT, 1)
+		//outputs
+		val busy_o = UInt(OUTPUT, 1) //to PATMOS
+		val DACLRC_o = UInt(OUTPUT, 1) //to WM8731
+		val DACDAT_o = UInt(OUTPUT, 1) //to WM8731
+	}
+
+
+	//Counter for audio sampling
+	val Fs_CYCLES = UInt(FS_DIV - 1); 
+	val Fs_cntReg = Reg(init = UInt(0, 9)) //counter register for Fs
+
+	val audio_cntReg = Reg(init = UInt(0, 5)) //counter register for Audio bits: max 32 bits: 5 bit counter
+
+	//states
+	val s_idle :: s_start :: s_left :: s_right :: Nil = Enum(UInt(), 4)
+	//state register
+	val state = Reg(init = s_idle)
+
+	//Registers for outputs:
+	val DACLRC_reg = Reg(init = UInt(0, 1))
+	val DACDAT_reg = Reg(init = UInt(0, 1))
+	val busy_reg = Reg(init = UInt(0, 1))
+	//assign to ouputs
+	io.DACLRC_o 	:= DACLRC_reg
+	io.DACDAT_o 	:= DACDAT_reg
+	io.busy_o 	:= busy_reg
+
+	//registers for audio data
+	val audio_l_reg = Reg(init = UInt(0, AUDIO_BITLENGTH))
+	val audio_r_reg = Reg(init = UInt(0, AUDIO_BITLENGTH))
+
+	//register for BCLK_i
+	val BCLK_reg = Reg(init = UInt(0, 1))
+	BCLK_reg := io.BCLK_i
+
+	//connect inputs to registers when not busy
+	when(busy_reg === UInt(0)) {
+		audio_l_reg := io.audio_l_i
+		audio_r_reg := io.audio_r_i
+	}
+
+	
+	when(io.en_dac_i === UInt(1)) { //when conversion is enabled
+
+		//state machine: on falling edge of BCLK
+		when( (io.BCLK_i =/= BCLK_reg) && (io.BCLK_i === UInt(0)) ) {
+
+			//counter for audio sampling
+			Fs_cntReg := Fs_cntReg + UInt(1)
+			when(Fs_cntReg === Fs_CYCLES) 
+			{
+				Fs_cntReg := UInt(0) //reset to 0
+			}    
+
+			//FSM for audio conversion
+			switch (state) {
+				is (s_idle) 
+				{
+					DACLRC_reg := UInt(0)
+					DACDAT_reg := UInt(0)
+					busy_reg := UInt(0)
+					when(Fs_cntReg === UInt(0)) {
+						state := s_start
+					}
+				}
+				is (s_start) 
+				{
+					DACLRC_reg := UInt(1)
+					busy_reg := UInt(1)
+					state := s_left //directly jump to next state
+				}
+				is (s_left) 
+				{
+					DACLRC_reg := UInt(0)
+					busy_reg := UInt(1)
+					DACDAT_reg := audio_l_reg( UInt(AUDIO_BITLENGTH) - audio_cntReg - UInt(1))
+					when (audio_cntReg < UInt(AUDIO_BITLENGTH-1)) 
+					{
+						audio_cntReg := audio_cntReg + UInt(1)
+					}
+					.otherwise //bit AUDIO_BITLENGTH-1
+					{ 
+		   				audio_cntReg := UInt(0) //restart counter
+						state := s_right
+					}
+				}
+				is (s_right) 
+				{
+					busy_reg := UInt(1)
+					DACDAT_reg := audio_r_reg(UInt(AUDIO_BITLENGTH) - audio_cntReg - UInt(1))
+					when (audio_cntReg < UInt(AUDIO_BITLENGTH-1)) 
+					{
+						audio_cntReg := audio_cntReg + UInt(1)
+					}
+					.otherwise 	 //bit AUDIO_BITLENGTH-1
+					{
+						audio_cntReg := UInt(0) //restart counter
+						state := s_idle
+					}
+				}
+			}
+		}
+	}
+	.otherwise //when conversion is disabled
+	{ 
+		state := s_idle
+		Fs_cntReg := UInt(0)
+		audio_cntReg := UInt(0)
+		busy_reg := UInt(0)	
+		DACLRC_reg := UInt(0)
+		DACDAT_reg := UInt(0)   
+	}
+  
+}

--- a/hardware/src/io/audio_i2c.scala
+++ b/hardware/src/io/audio_i2c.scala
@@ -1,0 +1,199 @@
+
+
+
+package io
+
+import Chisel._
+
+class audio_i2c extends Module 
+{
+	//constant: I2C slave address
+	val SLAVE_ADDR = "b0011010"
+	//IOs
+	val io = new Bundle 
+	{
+		//inputs from PATMOS
+		val data_i = UInt(INPUT, 9)
+		val addr_i = UInt(INPUT, 7)
+		//val rw_i = UInt(INPUT, 1) //temporarily disabled
+		//wires to  to WM8731
+		val sdin_i = UInt(INPUT, 1) //inout
+		val sdin_o = UInt(OUTPUT, 1) //inout
+		val sclk_o = UInt(OUTPUT, 1) //output
+		val we_o = UInt(OUTPUT, 1) // write enable: 1->sdin_o, 0->sdin_i
+		//handshake with patmos
+		val req_i = UInt(INPUT, 1)
+		val ack_o = UInt(OUTPUT, 1)
+	}
+
+	//registers for audio data
+	val data_reg = Reg(init = UInt(0, 9))
+	val addr_reg = Reg(init = UInt(0, 7))
+	
+	//connect inputs to registers
+	data_reg := io.data_i
+	addr_reg := io.addr_i
+
+	//clock divider for SCLK
+	val sclk_cntReg	 = Reg(init = UInt(0, 10)) 	//10 bit counter
+	val sclk_cntMax  = UInt(400/2) 				// 80 MHz -> 400 cycles -> 200 kHz
+	val sclk_cntMax2 = UInt(400) 				// Only used for finishing conditions
+
+	val word_cntReg = Reg(init = UInt(0, 3)) 	//counter register for each word: 8 bit counter (000 to 111)
+
+	//register for SCLK
+	val sclk_reg = Reg(init = UInt(1, 1)) 		//default high
+	io.sclk_o := sclk_reg
+	//register for SDIN_O
+	val sdin_reg = Reg(init = UInt(1, 1)) 		//default high
+	io.sdin_o := sdin_reg
+	//register for WE_O
+	val we_reg = Reg(init = UInt(1, 1)) 		//default high: master controls SDIN
+	io.we_o := we_reg
+
+	//register for R_ADDR: constant
+	val r_addr_reg = Reg(init = UInt(SLAVE_ADDR, 7))
+
+	//states
+	val s_idle :: s_start :: s_ack_1 :: s_data_msb :: s_ack_2 :: s_data_lsb :: s_ack_3 :: s_finish_1 :: s_finish_2 :: s_finish_patmos :: Nil = Enum(UInt(), 10)
+	//state register
+	val state = Reg(init = s_idle)
+
+	//Default values:
+	io.ack_o 	:= UInt(0)
+
+	when (io.req_i === UInt(1)) 
+	{ //PATMOS starts handshake
+
+		//initial transition: idle to start
+		when(state === s_idle) {
+			we_reg := UInt(1)
+			sdin_reg := UInt(0)
+			state := s_start
+		}
+		.elsewhen(state === s_finish_2) {
+			//counter for SCLK
+			sclk_cntReg := sclk_cntReg + UInt(1)
+			when(sclk_cntReg === sclk_cntMax) {
+				sclk_reg := UInt(1)
+			}
+			.elsewhen(sclk_cntReg === sclk_cntMax2) {
+				sclk_cntReg := UInt(0)
+				sdin_reg := UInt(1)
+				io.ack_o := UInt(1) //to PATMOS
+				state := s_finish_patmos
+			}
+		}
+		.elsewhen(state === s_finish_patmos) {
+			io.ack_o := UInt(1) //to PATMOS
+		}
+
+		//in any other state, enable counter and everything
+		.otherwise{
+			//counter for SCLK
+			sclk_cntReg := sclk_cntReg + UInt(1)
+			//when limit - 1 -> switch
+			when( sclk_cntReg === (sclk_cntMax - UInt(1)) ) {
+				sclk_reg := ~sclk_reg
+			}
+			//when limit -> restart counter
+			.elsewhen(sclk_cntReg === sclk_cntMax) 
+			{
+				sclk_cntReg := UInt(0)
+				//update state machine only at falling edge
+				when (sclk_reg === UInt(0)) {
+					switch (state) {
+						is (s_start) {
+							when(word_cntReg < UInt(7)){
+								sdin_reg := r_addr_reg(UInt(6)-word_cntReg)
+								word_cntReg := word_cntReg + UInt(1)
+							}
+							.otherwise {//word_cntReg === UInt(7)) 
+								sdin_reg := UInt(0) //for write
+								word_cntReg := UInt(0)
+								state := s_ack_1
+							}
+						}
+						is (s_ack_1) {
+							we_reg := UInt(0)
+							sdin_reg := UInt(1) //doesn't really matter
+							state := s_data_msb
+
+						}
+						is (s_data_msb) {
+							we_reg := UInt(1)
+							//check if WM8731 responded with ACK correctly on the first CC of this state
+							when(  (sclk_cntReg === UInt(0)) && (io.sdin_i === UInt(1)) ) {
+								//in this case, reset
+								sclk_cntReg := UInt(0)
+								state := s_idle
+							}
+							//if it ACK is correct (sdin === 0), then proceed
+							when(word_cntReg < UInt(7)){
+								sdin_reg := addr_reg(UInt(6)-word_cntReg)
+								word_cntReg := word_cntReg + UInt(1)
+							}
+							.otherwise {//word_cntReg === UInt(7)) 
+								sdin_reg := data_reg(UInt(8))
+								word_cntReg := UInt(0)
+								state := s_ack_2
+							}
+						}
+						is (s_ack_2) {
+							we_reg := UInt(0)
+							sdin_reg := UInt(1) //doesn't really matter
+							state := s_data_lsb
+						}
+						is (s_data_lsb) {
+							we_reg := UInt(1)
+							//check if WM8731 responded with ACK correctly on the first CC of this state
+							when(  (sclk_cntReg === UInt(0)) && (io.sdin_i === UInt(1)) ) {
+								//in this case, reset
+								sclk_cntReg := UInt(0)
+								state := s_idle
+							}
+							//if it ACK is correct (sdin === 0), then proceed
+							when(word_cntReg < UInt(7)){
+								sdin_reg := data_reg(UInt(7)-word_cntReg)
+								word_cntReg := word_cntReg + UInt(1)
+							}
+							.otherwise {//word_cntReg === UInt(7)) 
+								sdin_reg := data_reg(UInt(0))
+								word_cntReg := UInt(0)
+								state := s_ack_3
+							}
+						}
+						is (s_ack_3) {
+							we_reg := UInt(0)
+							sdin_reg := UInt(0) //I think it matters on this case
+							state := s_finish_1
+						}
+						//added
+						is (s_finish_1) {
+							we_reg := UInt(1)
+							sdin_reg := UInt(0)
+							//check if WM8731 responded with ACK correctly
+							when(io.sdin_i === UInt(0)) {
+								state := s_finish_2
+							}
+							.otherwise { // if no ack
+								state := s_idle
+							}
+						}
+					}
+				}
+			}	
+		}
+	}			
+	.otherwise { //io.req_i === UInt(0)
+		when (state === s_finish_patmos) {
+			state := s_idle
+		}
+	}
+			      
+
+		
+  
+}
+
+

--- a/hardware/src/io/audio_interface.scala
+++ b/hardware/src/io/audio_interface.scala
@@ -1,0 +1,200 @@
+/*
+ * Audio Codec module in chisel.
+ *
+ * Author: Daniel Sanz Ausin s142290 & Fabian Goerge s150957
+ *
+ */
+
+package io
+
+import Chisel._
+import Node._
+
+import patmos.Constants._
+import util.Config
+import util.Utility
+
+import ocp._
+
+object audio_interface extends DeviceObject 
+{
+	//Audio Register length: can be 16 or 24
+	var audioLength  = -1
+	//Audio Frequency divider
+	var audioFsDivider = -1
+	//Clock divider for the audio interface
+	var audioClkDivider = -1
+
+
+	def init(params: Map[String, String]) = 
+	{
+		audioLength		= getPosIntParam(params, "audioLength")
+		audioFsDivider		= getPosIntParam(params, "audioFsDivider")
+		audioClkDivider		= getPosIntParam(params, "audioClkDivider")
+	}
+	
+	def create(params: Map[String, String]) : audio_interface = 
+	{
+	    Module	(new audio_interface (audioLength, audioFsDivider, audioClkDivider) )
+	}
+
+	trait Pins 
+	{
+		val audio_interfacePins = new Bundle() 
+		{
+			// Digital Audio Interface 
+			val dacDat	= Bits (OUTPUT, 1)		
+			val dacLrc 	= Bits (OUTPUT, 1) 
+			val adcDat	= Bits (INPUT, 1)	
+			val adcLrc	= Bits (OUTPUT, 1)	
+
+			// I2C - Control Interface
+			val sdIn	= Bits (INPUT, 1)
+			val sdOut 	= Bits (OUTPUT, 1)
+			val we		= Bits (OUTPUT, 1)
+			val sclkOut	= Bits (OUTPUT, 1)		
+						
+			val xclk	= Bits (OUTPUT,1)		
+			val bclk 	= Bits (OUTPUT,1)		
+		}
+	}
+
+
+
+}
+
+class audio_interface(	audioLength: Int,
+			audioFsDivider: Int,
+			audioClkDivider: Int ) extends CoreDevice() 
+{
+	override val io = new CoreDeviceIO() with audio_interface.Pins
+
+	val audioFsDividerReg		= Reg(init = Bits(audioFsDivider,9))
+	val audioClkDividerReg		= Reg(init = Bits(audioClkDivider,5))
+	val audioLengthReg		= Reg(init = Bits(audioLength,5))
+
+	val audioDacLReg		= Reg(init = Bits(0, audioLength))	//16 or 24 Bit of Audio input Data
+	val audioDacRReg		= Reg(init = Bits(0, audioLength))	//16 or 24 Bit of Audio input Data
+	val audioDacEnReg		= Reg(init = Bits(0, 1))		//1  Bit to turn on the Audio device
+	val audioDacBusyReg		= Reg(init = Bits(0, 1))		//1  Bit acknowledge signal
+	val audioDacReqReg		= Reg(init = Bits(0, 1))		//1  Bit request signal
+	val audioDacLrcReg		= Reg(init = Bits(0, 1))
+
+	val audioAdcLOReg		= Reg(init = Bits(0, audioLength))	//16 or 24 Bit of Audio output Data
+	val audioAdcROReg		= Reg(init = Bits(0, audioLength))	//16 or 24 Bit of Audio output Data
+	val audioAdcENReg		= Reg(init = Bits(0, 1))		//1  Bit to enable on the Audio device
+	val audioAdcBusyReg		= Reg(init = Bits(0, 1))		//1  Bit acknowledge signal
+	val audioAdcReqReg		= Reg(init = Bits(0, 1))		//1  Bit request signal
+	val audioAdcLrcReg		= Reg(init = Bits(0, 1))
+
+	val i2cDataReg 			= Reg(init = Bits(0,9))			//9 Bit I2C data	
+	val i2cAdrReg			= Reg(init = Bits(0, 7))		//7 Bit I2C address
+	val i2cAckReg			= Reg(init = Bits(0, 1))		//1  Bit acknowledge signal
+	val i2cReqReg 			= Reg(init = Bits(0, 1))			//1  Bit request signal		
+
+	// Default response
+	val respReg = Reg(init = OcpResp.NULL)
+	respReg := OcpResp.NULL
+
+	// Read Audio IN
+	when(io.ocp.M.Cmd === OcpCmd.RD) 
+	{
+		respReg := OcpResp.DVA
+	}
+	
+
+	// Read information
+	val masterReg = Reg(next = io.ocp.M)
+  	val data = Bits(width = DATA_WIDTH)
+  	data := Bits(0)		//Default Data
+
+	switch(masterReg.Addr(8,4)) 
+	{
+		is(Bits("b0000")) { data := audioDacLReg }	
+		is(Bits("b0001")) { data := audioDacRReg }	
+		is(Bits("b0010")) { data := audioDacEnReg }	 
+		is(Bits("b0011")) { data := audioDacBusyReg }	
+		is(Bits("b0100")) { data := audioDacReqReg }	
+		is(Bits("b0101")) { data := audioDacLrcReg }	
+		is(Bits("b0110")) { data := audioAdcLOReg }
+		is(Bits("b0111")) { data := audioAdcROReg }
+		is(Bits("b1000")) { data := audioAdcENReg }		
+		is(Bits("b1001")) { data := audioAdcBusyReg }	
+		is(Bits("b1010")) { data := audioAdcReqReg }	
+		is(Bits("b1011")) { data := audioAdcLrcReg }	
+		is(Bits("b1100")) { data := i2cDataReg } 
+		is(Bits("b1101")) { data := i2cAdrReg }	
+		is(Bits("b1110")) { data := i2cAckReg }
+		is(Bits("b1111")) { data := i2cReqReg }
+	}
+
+	// Write Audio In
+	when(io.ocp.M.Cmd === OcpCmd.WR) 
+	{
+		respReg := OcpResp.DVA
+		switch(io.ocp.M.Addr(8,4)) 
+		{
+			is(Bits("b0000")) { audioDacLReg		:= io.ocp.M.Data(audioLength-1,0) }
+			is(Bits("b0001")) { audioDacRReg		:= io.ocp.M.Data(audioLength-1,0) }
+			is(Bits("b0010")) { audioDacEnReg	 	:= io.ocp.M.Data(0)} 
+			is(Bits("b0100")) { audioDacReqReg		:= io.ocp.M.Data(0)} 
+			is(Bits("b1000")) { audioAdcENReg		:= io.ocp.M.Data(0)}
+			is(Bits("b1010")) { audioAdcReqReg		:= io.ocp.M.Data(0)}	
+			is(Bits("b1100")) { i2cDataReg 			:= io.ocp.M.Data(8,0)}	
+			is(Bits("b1101")) { i2cAdrReg 			:= io.ocp.M.Data(6,0)}	
+			is(Bits("b1111")) { i2cReqReg 			:= io.ocp.M.Data(0)}	
+		}
+	} 
+	
+	// Connections to master
+	io.ocp.S.Resp := respReg
+	io.ocp.S.Data := data
+
+
+	//Audio Clock Unit:
+	val mAudioClk = Module(new audio_clk_gen(audioClkDivider))
+		mAudioClk.io.en_adc_i 		:= audioAdcENReg
+		mAudioClk.io.en_dac_i		:= audioDacEnReg
+	    	io.audio_interfacePins.bclk	:= mAudioClk.io.BCLK_o 
+		io.audio_interfacePins.xclk	:= mAudioClk.io.XCLK_o
+
+
+	//Dac:
+	val mAudioDac = Module(new audio_dac(audioLength, audioFsDivider))
+
+		mAudioDac.io.audio_l_i		:= audioDacLReg
+		mAudioDac.io.audio_r_i		:= audioDacRReg
+    		mAudioDac.io.en_dac_i		:= audioDacEnReg
+		mAudioDac.io.BCLK_i		:= mAudioClk.io.BCLK_o
+		audioDacBusyReg			:= mAudioDac.io.busy_o 
+
+		audioDacLrcReg			:= mAudioDac.io.DACLRC_o
+	    	io.audio_interfacePins.dacLrc	:= mAudioDac.io.DACLRC_o 
+		io.audio_interfacePins.dacDat	:= mAudioDac.io.DACDAT_o
+
+	//Adc:
+	val mAudioAdc = Module(new audio_adc(audioLength, audioFsDivider))
+		audioAdcLOReg 			:= mAudioAdc.io.audio_l_o 
+		audioAdcROReg 			:= mAudioAdc.io.audio_r_o
+		audioAdcBusyReg 		:= mAudioAdc.io.busy_o 		
+		mAudioAdc.io.en_adc_i 		:= audioAdcENReg
+		mAudioAdc.io.BCLK_i 		:= mAudioClk.io.BCLK_o
+
+		audioAdcLrcReg			:= mAudioAdc.io.ADCLRC_o
+		io.audio_interfacePins.adcLrc 	:= mAudioAdc.io.ADCLRC_o 
+		mAudioAdc.io.ADCDAT_i 		:= io.audio_interfacePins.adcDat
+
+	//IC2 Control Interface
+	val mAudioCtrl = Module(new audio_i2c())
+		mAudioCtrl.io.data_i 		:= i2cDataReg
+		mAudioCtrl.io.addr_i 		:= i2cAdrReg
+    		mAudioCtrl.io.req_i 		:= i2cReqReg
+		i2cAckReg 			:= mAudioCtrl.io.ack_o 
+	    
+		mAudioCtrl.io.sdin_i 		:= io.audio_interfacePins.sdIn 		
+		io.audio_interfacePins.we 	:= mAudioCtrl.io.we_o
+		io.audio_interfacePins.sdOut 	:= mAudioCtrl.io.sdin_o
+		io.audio_interfacePins.sclkOut 	:= mAudioCtrl.io.sclk_o
+}
+
+

--- a/hardware/vhdl/patmos_de2-115-audio.vhdl
+++ b/hardware/vhdl/patmos_de2-115-audio.vhdl
@@ -1,0 +1,192 @@
+--
+-- Copyright: 2013, Technical University of Denmark, DTU Compute
+-- Author: Martin Schoeberl (martin@jopdesign.com)
+--         Rasmus Bo Soerensen (rasmus@rbscloud.dk)
+-- License: Simplified BSD License
+--
+
+-- VHDL top level for Patmos in Chisel on Altera de2-115 board
+--
+-- Includes some 'magic' VHDL code to generate a reset after FPGA configuration.
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity patmos_top is
+	port(
+		clk : in  std_logic;
+		oLedsPins_led : out std_logic_vector(8 downto 0);
+		iKeysPins_key : in std_logic_vector(3 downto 0);
+		oUartPins_txd : out std_logic;
+		iUartPins_rxd : in  std_logic;
+        oSRAM_A : out std_logic_vector(19 downto 0);
+        SRAM_DQ : inout std_logic_vector(15 downto 0);
+        oSRAM_CE_N : out std_logic;
+        oSRAM_OE_N : out std_logic;
+        oSRAM_WE_N : out std_logic;
+        oSRAM_LB_N : out std_logic;
+        oSRAM_UB_N : out std_logic;
+		oAudio_dacDat	: out std_logic;	
+		oAudio_dacLrc	: out std_logic;
+		iAudio_adcDat	: in std_logic;
+		oAudio_adcLrc	: out std_logic;
+		ioAudio_sdat	: inout std_logic;
+		oAudio_sclk	: out std_logic;
+		oAudio_bclk	: out std_logic;
+		oAudio_xclk	: out std_logic
+	);
+end entity patmos_top;
+
+architecture rtl of patmos_top is
+	component Patmos is
+		port(
+			clk             : in  std_logic;
+			reset           : in  std_logic;
+
+			io_comConf_M_Cmd        : out std_logic_vector(2 downto 0);
+			io_comConf_M_Addr       : out std_logic_vector(31 downto 0);
+			io_comConf_M_Data       : out std_logic_vector(31 downto 0);
+			io_comConf_M_ByteEn     : out std_logic_vector(3 downto 0);
+			io_comConf_M_RespAccept : out std_logic;
+			io_comConf_S_Resp       : in std_logic_vector(1 downto 0);
+			io_comConf_S_Data       : in std_logic_vector(31 downto 0);
+			io_comConf_S_CmdAccept  : in std_logic;
+
+			io_comSpm_M_Cmd         : out std_logic_vector(2 downto 0);
+			io_comSpm_M_Addr        : out std_logic_vector(31 downto 0);
+			io_comSpm_M_Data        : out std_logic_vector(31 downto 0);
+			io_comSpm_M_ByteEn      : out std_logic_vector(3 downto 0);
+			io_comSpm_S_Resp        : in std_logic_vector(1 downto 0);
+			io_comSpm_S_Data        : in std_logic_vector(31 downto 0);
+
+			io_cpuInfoPins_id   : in  std_logic_vector(31 downto 0);
+			io_cpuInfoPins_cnt  : in  std_logic_vector(31 downto 0);
+			io_ledsPins_led : out std_logic_vector(8 downto 0);
+			io_keysPins_key : in  std_logic_vector(3 downto 0);
+			io_uartPins_tx  : out std_logic;
+			io_uartPins_rx  : in  std_logic;
+
+            io_sramCtrlPins_ramOut_addr : out std_logic_vector(19 downto 0);
+            io_sramCtrlPins_ramOut_doutEna : out std_logic;
+            io_sramCtrlPins_ramIn_din : in std_logic_vector(15 downto 0);
+            io_sramCtrlPins_ramOut_dout : out std_logic_vector(15 downto 0);
+            io_sramCtrlPins_ramOut_nce : out std_logic;
+            io_sramCtrlPins_ramOut_noe : out std_logic;
+            io_sramCtrlPins_ramOut_nwe : out std_logic;
+            io_sramCtrlPins_ramOut_nlb : out std_logic;
+            io_sramCtrlPins_ramOut_nub : out std_logic;
+
+			io_audio_interfacePins_dacDat	: out std_logic;	
+			io_audio_interfacePins_dacLrc	: out std_logic;
+			io_audio_interfacePins_adcDat	: in std_logic;
+			io_audio_interfacePins_adcLrc	: out std_logic;
+			io_audio_interfacePins_sdIn		: in std_logic;
+			io_audio_interfacePins_sdOut 	: out std_logic;
+			io_audio_interfacePins_we 		: out std_logic;
+			io_audio_interfacePins_sclkOut 	: out std_logic;
+    		io_audio_interfacePins_bclk		: out std_logic;
+    		io_audio_interfacePins_xclk		: out std_logic
+
+		);
+	end component;
+
+	-- DE2-70: 50 MHz clock => 80 MHz
+	-- BeMicro: 16 MHz clock => 25.6 MHz
+	constant pll_infreq : real    := 50.0;
+	constant pll_mult   : natural := 8;
+	constant pll_div    : natural := 5;
+
+	signal clk_int : std_logic;
+
+	-- for generation of internal reset
+	signal int_res            : std_logic;
+	signal res_reg1, res_reg2 : std_logic;
+	signal res_cnt            : unsigned(2 downto 0) := "000"; -- for the simulation
+
+    -- sram signals for tristate inout
+    signal sram_out_dout_ena : std_logic;
+    signal sram_out_dout : std_logic_vector(15 downto 0);
+
+	-- audio siganls for tristate inout
+	signal saudio_sdIn		: std_logic;
+	signal saudio_sdOut 	: std_logic;
+	signal saudio_we 		: std_logic;
+	signal saudio_sclkOut 	: std_logic;
+
+	attribute altera_attribute : string;
+	attribute altera_attribute of res_cnt : signal is "POWER_UP_LEVEL=LOW";
+
+begin
+	pll_inst : entity work.pll generic map(
+			input_freq  => pll_infreq,
+			multiply_by => pll_mult,
+			divide_by   => pll_div
+		)
+		port map(
+			inclk0 => clk,
+			c0     => clk_int
+		);
+	-- we use a PLL
+	-- clk_int <= clk;
+
+	--
+	--	internal reset generation
+	--	should include the PLL lock signal
+	--
+	process(clk_int)
+	begin
+		if rising_edge(clk_int) then
+			if (res_cnt /= "111") then
+				res_cnt <= res_cnt + 1;
+			end if;
+			res_reg1 <= not res_cnt(0) or not res_cnt(1) or not res_cnt(2);
+			res_reg2 <= res_reg1;
+			int_res  <= res_reg2;
+		end if;
+	end process;
+
+
+    -- tristate output to ssram
+    process(sram_out_dout_ena, sram_out_dout)
+    begin
+      if sram_out_dout_ena='1' then
+        SRAM_DQ <= sram_out_dout;
+      else
+        SRAM_DQ <= (others => 'Z');
+      end if;
+    end process;
+
+
+	-- Audio I2C tristate buffer control
+  	--ioAudio_sdat <= saudio_sdOut when (saudio_we  = '0') else 'Z';
+	--saudio_sdIn <= ioAudio_sdat when (saudio_we ='1') else '1';
+	process(saudio_we, saudio_sdOut)
+		begin
+		if saudio_we = '1' then
+			ioAudio_sdat <= saudio_sdOut;
+			saudio_sdIn <= '1';
+		else
+			ioAudio_sdat <= 'Z';
+			saudio_sdIn <= ioAudio_sdat;
+		end if;
+	end process;
+		
+	
+	-- Not tristate
+	oAudio_sclk <= saudio_sclkOut;
+
+    comp : Patmos port map(clk_int, int_res,
+           open, open, open, open, open,
+           (others => '0'), (others => '0'), '0',
+           open, open, open, open,
+           (others => '0'), (others => '0'),
+           X"00000000", X"00000001",
+           oLedsPins_led,
+           iKeysPins_key,
+           oUartPins_txd, iUartPins_rxd,
+           oSRAM_A, sram_out_dout_ena, SRAM_DQ, sram_out_dout, oSRAM_CE_N, oSRAM_OE_N, oSRAM_WE_N, oSRAM_LB_N, oSRAM_UB_N,
+			oAudio_dacDat, oAudio_dacLrc, iAudio_adcDat, oAudio_adcLrc, saudio_sdIn, saudio_sdOut, saudio_we, saudio_sclkOut, oAudio_bclk, oAudio_xclk );
+
+end architecture rtl;


### PR DESCRIPTION
An audio interface for PATMOS has been added, which runs on the ALTDE2-115 FPGA.

Description of the added files:
-Chisel modules for audio interface
-C programs for testing
-XML configuration file
-VHDL file
-Quartus constraints file - .qsf (modifications in Makefile might be needed to choose this qsf file)