### PR TITLE
Interfacing SD cards on Altera DE2-115

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -10,6 +10,7 @@ LIBCORETHREAD=$(BUILDDIR)/libcorethread.a
 LIBETH=$(BUILDDIR)/libeth.a
 LIBAUDIO=$(BUILDDIR)/libaudio.a
 LIBELF=$(BUILDDIR)/libelf.a
+LIBSD=$(BUILDDIR)/libsd.a
 
 NOCINIT?=cmp/nocinit.c
 
@@ -69,9 +70,9 @@ $(BUILDDIR)/%.o: %.c Makefile
 	$(CC) $(CFLAGS) -c -o $@ $(filter %.c,$^)
 
 # A target for regular applications
-$(BUILDDIR)/%.elf: %.c $(NOCINIT) $(LIBMP) $(LIBNOC) $(LIBCORETHREAD) $(LIBETH) $(LIBAUDIO) $(LIBELF) Makefile
+$(BUILDDIR)/%.elf: %.c $(NOCINIT) $(LIBMP) $(LIBNOC) $(LIBCORETHREAD) $(LIBETH) $(LIBSD) $(LIBAUDIO) $(LIBELF) Makefile
 	mkdir -p $(BUILDDIR)/$(dir $*)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.s,$^) -L$(BUILDDIR) -lmp -lnoc -lcorethread -leth -lelf -lm -laudio
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.s,$^) -L$(BUILDDIR) -lmp -lnoc -lcorethread -leth -lelf -lsd -lm -laudio
 
 $(BUILDDIR)/%.s: %.c Makefile
 	mkdir -p $(BUILDDIR)/$(dir $*)
@@ -89,7 +90,7 @@ $(BUILDDIR)/bootable-%.s: %.c Makefile
 # A target for applications that use virtual memory
 $(BUILDDIR)/vm-%.elf: %.c $(NOCINIT) $(LIBMP) $(LIBNOC) $(LIBCORETHREAD) $(LIBETH) $(LIBELF) Makefile
 	mkdir -p $(BUILDDIR)/$(dir $*)
-	$(CC) $(CFLAGS-VM) $(LDFLAGS-VM) -o $@ $(filter %.c %.s,$^) -L$(BUILDDIR) -lmp -lnoc -lcorethread -leth -lelf
+	$(CC) $(CFLAGS-VM) $(LDFLAGS-VM) -o $@ $(filter %.c %.s,$^) -L$(BUILDDIR) -lmp -lnoc -lsd -lcorethread -leth -lelf
 
 # application-specific additional dependencies
 $(BUILDDIR)/bootable-bootloader.elf: download.c decompress.c ethmac.c boot.h bootable.h
@@ -163,4 +164,10 @@ $(LIBAUDIO): $(BUILDDIR)/libaudio/dsp_algorithms.o $(BUILDDIR)/libaudio/audio.o
 .PHONY: libelf
 libelf: $(LIBELF)
 $(LIBELF): $(patsubst libelf/%.c,$(BUILDDIR)/libelf/%.o,$(wildcard libelf/*.c))
+	patmos-ar r $@ $^
+
+# library for using SD card
+.PHONY: libsd
+libsd: $(LIBSD)
+$(LIBSD): $(patsubst libsd/%.c,$(BUILDDIR)/libsd/%.o,$(wildcard libsd/*.c))
 	patmos-ar r $@ $^

--- a/c/libsd/fat32.c
+++ b/c/libsd/fat32.c
@@ -1,0 +1,2024 @@
+/*
+   Copyright 2017 Max Rishoej Pedersen
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * Library for accessing files on FAT32 formatted disk.
+ *
+ * Authors: Max Rishoej (maxrishoej@gmail.com)
+ */
+
+#include "fat32.h"
+#include "sddisk.h"
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <sys/types.h>
+
+#include <stdio.h>
+
+// --- Defines ---
+
+// Internally useful exit codes
+#define FAT_SUCCESS (0)
+#define FAT_FAIL (-1)
+
+// Constants relevant for reading partition information
+#define PTABLE_BEGIN (446)
+#define PTABLE_ENTRY_SIZE (16)
+#define PTABLE_TYPE_OFFSET (4)
+#define PTABLE_VOL_ADDR_OFFSET (8)
+
+// Supported parition type
+#define FAT_PARTITION_SIG_CHS (0x0B)
+#define FAT_PARTITION_SIG_LBA (0x0C)
+
+// Maximum number of open files at a time
+#define FAT_MAX_FILES (16)
+
+#define FAT_MAX_SHORT_PATH (81) // 80 path + trailing NUL
+#define FAT_MAX_LONG_PATH (261) // 260 path + trailing NUL
+#define FAT_MAX_LONG_NAME (255) // No trailing NUL
+
+// Offset of file descriptors, to avoid clashing with stdin / stdout / stderr
+#define FAT_FD_OFFSET (3)
+
+// Values of directory entries
+#define FAT_DIR_ENTRY_FREE (0xE5)
+#define FAT_DIR_ENTRY_LAST (0x00)
+#define FAT_LAST_LONG      (0x40)
+
+// Macros for checking FAT table values
+#define FAT_TV_LAST(v) ((v) >= 0x0FFFFFF8)
+#define FAT_TV_BAD(v) ((v) == 0x0FFFFFF7)
+#define FAT_TV_FREE(v) ((v) == 0)
+
+#define FAT_DIR_ENTRY_WIDTH (32) // Width of a directory entry in bytes
+
+// Attributes of directory entries
+#define FAT_DIRECTORY (0x10)
+#define FAT_ARCHIVE   (0x20)
+
+const uint32_t FAT_LONG_NAME_ENTRY = 0
+  | 0x01  // Read Only
+  | 0x02  // Hidden
+  | 0x04  // System
+  | 0x08; // VolumeID
+
+// --- Fields ---
+
+FatFile fat_open_files[FAT_MAX_FILES]; // All files of the system
+
+// Buffers
+uint16_t long_name16[FAT_MAX_LONG_NAME];
+uint8_t long_name8[FAT_MAX_LONG_NAME];
+
+FatPartitionInfo fat_pinfo; // Loaded FatPartitionInfo.
+int32_t fat_initialized = 0; // Has the library been initiliazed?
+
+// --- Internal functions ---
+static inline uint32_t umin(uint32_t a, uint32_t b) {
+  return a < b ? a : b;
+}
+
+int fat_read_single_block(unsigned int addr, uint8_t *buffer) {
+  if (0 == disk_read(addr, buffer, 1)) {
+    return FAT_SUCCESS;
+  }
+
+  errno = EIO;
+  return FAT_FAIL;
+}
+
+int fat_write_single_block(unsigned int addr, uint8_t *buffer) {
+  if (0 == disk_write(addr, buffer, 1)) {
+    return FAT_SUCCESS;
+  }
+
+  errno = EIO;
+  return FAT_FAIL;
+}
+
+// Reads a little-endian value from a buffer
+inline uint32_t fat_get_uint32(uint8_t *buf) {
+  return buf[0] + (buf[1] << 8) +
+    (buf[2] << 16) + (buf[3] << 24);
+}
+inline uint16_t fat_get_uint16(uint8_t *buf) {
+  return buf[0] + (buf[1] << 8);
+}
+inline uint8_t fat_get_uint8(uint8_t *buf) {
+  return buf[0];
+}
+
+// Sets a little-endian value in buffer
+inline void fat_set_uint32(uint32_t v, uint8_t *buf) {
+  buf[0] = (uint8_t)v;
+  buf[1] = (uint8_t)(v >> 8);
+  buf[2] = (uint8_t)(v >> 16);
+  buf[3] = (uint8_t)(v >> 24);
+}
+inline void fat_set_uint16(uint16_t v, uint8_t *buf) {
+  buf[0] = (uint8_t)v;
+  buf[1] = (uint8_t)(v >> 8);
+}
+inline void fat_set_uint8(uint16_t v, uint8_t *buf) {
+  buf[0] = (uint8_t)v;
+}
+
+// Reads byte array from a read sector
+inline void fat_get_string(uint8_t *buf, uint8_t *str, uint32_t sz) {
+  for (; sz > 0; --sz) {
+    *str++ = *buf++;
+  }
+}
+
+// Retrieves the attribute of directory entry in a read sector.
+inline uint8_t fat_attrib_of_dir_entry(uint8_t *sector, uint32_t entry_idx) {
+  return sector[entry_idx * FAT_DIR_ENTRY_WIDTH + 11]; // Just a single byte
+}
+
+// Returns the first sector of the given cluster
+inline uint32_t fat_first_sector_of_cluster(uint32_t cluster) {
+  return fat_pinfo.cluster_begin_addr +
+    (cluster - 2) * fat_pinfo.sectors_per_cluster;
+}
+
+/*! Returns the long name for directory entry.
+  Both buffers must be 512 bytes large.
+  First buffer is assumed to be loaded.
+  Works forward, updating idx and buffer.
+  Returns FAT_SUCCESS on succesful retrieval.
+  Sets errno.
+*/
+int fat_get_long_name_uint16(uint8_t *buffer, FatDirEntryIdx *idx, uint16_t *buf) {
+  int i = 0;
+  int c = 0;
+
+  uint8_t attrib = 0; // Attribute of entry
+  uint8_t order = 0; // Order of entry
+
+  uint32_t entries_per_sector = fat_pinfo.bytes_per_sector / 32;
+  uint32_t sec_start = fat_first_sector_of_cluster(idx->cluster);
+  uint32_t edx = idx->index * FAT_DIR_ENTRY_WIDTH; // Index of first byte of entry in sector
+
+  // Check non-empty entry
+  if (0xE5 == buffer[edx] || 0x00 == buffer[edx]) {
+    return FAT_FAIL; // Empty entry
+  }
+
+  // Check that its the first long name entry
+  attrib = fat_attrib_of_dir_entry(buffer, idx->index);
+  if (attrib != FAT_LONG_NAME_ENTRY || !(buffer[edx] & FAT_LAST_LONG)) {
+    return FAT_FAIL; // Not the first long entry
+  }
+
+  // Get the length of the chain
+  order = buffer[edx] ^ FAT_LAST_LONG;
+  uint32_t pmax = order * 13; // End of the long name
+  uint32_t pmin = pmax; // Start of every chunk write
+
+  int success = 0;
+  do {
+    // Check entries
+    while (idx->index < entries_per_sector) {
+      edx = idx->index * FAT_DIR_ENTRY_WIDTH;
+
+      attrib = buffer[edx + 11];
+      if (attrib != FAT_LONG_NAME_ENTRY) {
+        return FAT_FAIL; // Broken chain
+      }
+
+      // Collect name
+      c = 0;
+      pmin -= 13;
+      for (i = 0; i < 5; i++) {
+        buf[pmin + c + i] = buffer[edx + 1 + i*2];
+      }
+      c += 5;
+      for (i = 0; i < 6; i++) {
+        buf[pmin + c + i] = buffer[edx + 14 + i*2];
+      }
+      c += 6;
+      for (i = 0; i < 2; i++) {
+        buf[pmin + c + i] = buffer[edx + 28 + i*2];
+      }
+      c += 2;
+
+      idx->index++;
+
+      // Check order
+      order = buffer[edx] & FAT_LAST_LONG ?
+        buffer[edx] ^ FAT_LAST_LONG : buffer[edx];
+      if (order == 1) { // The last entry
+        buf[umin(255, pmax)] = 0; // Cap path
+        success = 1;
+        break;
+      }
+    }
+
+    // Stop, unless sector must be updated
+    if (success && idx->index < entries_per_sector) {
+      break;
+    }
+
+    // Next sector
+    if (idx->sector >= fat_pinfo.sectors_per_cluster - 1) {
+      return FAT_FAIL; // Reached start of cluster without finding long name
+    }
+    idx->sector++;
+    idx->index = 0;
+
+    if (FAT_SUCCESS != fat_read_single_block(sec_start + idx->sector, buffer)) {
+      success = 0;
+      break;
+    }
+  } while (c <= 255 && !success);
+
+  return success ? FAT_SUCCESS : FAT_FAIL;
+}
+
+/*! Gets the 8-bit version of the long name.
+  Buffer must be 512 bytes long and is assumed to be loaded.
+  Works forward in entries updating idx and buffer.
+ */
+uint32_t fat_get_long_name_uint8(uint8_t *buffer, FatDirEntryIdx *idx, uint8_t *long_name) {
+  int i;
+  uint32_t edx = idx->index * FAT_DIR_ENTRY_WIDTH; // Index of first byte of entry in sector
+
+  // Check entry entry
+  if (0xE5 == buffer[edx] || 0x00 == buffer[edx]) {
+    return FAT_FAIL; // Empty entry
+  }
+
+  // Check that its the first long name entry
+  uint8_t attrib = fat_attrib_of_dir_entry(buffer, idx->index);
+  int has_long_name = attrib == FAT_LONG_NAME_ENTRY && (buffer[edx] & FAT_LAST_LONG);
+
+  if (has_long_name) {
+    if (FAT_SUCCESS != fat_get_long_name_uint16(buffer, idx, long_name16)) {
+      return FAT_FAIL;
+    }
+    else {
+      for (i = 0; i < 256; i++) {
+        long_name[i] = (uint8_t)(long_name16[i]);
+      }
+    }
+  }
+  else {
+    uint8_t short_name[12]; // 11 bytes + null terminating
+    fat_get_string(buffer + idx->index * FAT_DIR_ENTRY_WIDTH, short_name, 11);
+    short_name[11] = 0; // Terminate
+
+    int k = 0;
+
+    // Name first
+    for (i = 0; i < 8; i++) {
+      if (short_name[i] != 0x20) {
+        long_name[k++] = short_name[i];
+      }
+      else {
+        break;
+      }
+    }
+
+    // Extension
+    if (short_name[8] != 0x20) {
+      long_name[k++] = '.';
+      for (i = 0; i < 3; i++) {
+        if (short_name[8 + i] != 0x20) {
+          long_name[k++] = short_name[8 + i];
+        }
+        else {
+          break;
+        }
+      }
+    }
+
+    // Cap
+    long_name[k] = 0;
+  }
+
+  return FAT_SUCCESS;
+}
+
+/*! Loads the first available FAT partition, if available.
+    Returns 0 on success, -1 on failure.
+ */
+int fat_load_first_partition_info(FatPartitionInfo *pinfo) {
+  uint8_t i;
+  for (i = 0; i < 4; i++) {
+    if (FAT_SUCCESS == fat_load_partition_info(i, pinfo)) {
+      return FAT_SUCCESS;
+    }
+  }
+
+  return FAT_FAIL;
+}
+
+/*! Loads the FAT partition in an entry, from the MBR.
+  Return 0 on success, -1 on failure.
+  Assumes block size is 512 bytes.
+
+  errno == EIO: Bad response from disk
+  errno == EBADF: Non-supported partition type
+  errno == EINVAL: Entry index out of range [0 - 3];
+*/
+int fat_load_partition_info(uint8_t idx, FatPartitionInfo *pinfo) {
+  uint8_t res;
+  uint8_t buffer[512]; // Buffer holding block
+
+  // TODO: Ensure DiskInfo block size matches FAT block size.
+
+  // Read data
+  res = fat_read_single_block(0, buffer);
+  if (0 != res) {
+    errno = EIO;
+    return FAT_FAIL;
+  }
+
+  if (idx >= 4) {
+    errno = EINVAL;
+    return FAT_FAIL;
+  }
+
+  // Sanity check that this is a MBR
+  // Expect byte 510 = 0x55 and 511 = 0xAA (signature / magic number)
+  if (buffer[510] != 0x55 && buffer[511] != 0xAA) {
+    errno = EFAULT;
+    return FAT_FAIL;
+  }
+
+  // Load partition info
+  uint8_t *pentry_begin = buffer + PTABLE_BEGIN + idx * PTABLE_ENTRY_SIZE;
+  uint8_t ptype = fat_get_uint8(pentry_begin + PTABLE_TYPE_OFFSET);
+  if (ptype != FAT_PARTITION_SIG_CHS && ptype != FAT_PARTITION_SIG_LBA) {
+    errno = EBADF;
+    return FAT_FAIL;
+  }
+
+  pinfo->vol_begin_addr = fat_get_uint32(pentry_begin + PTABLE_VOL_ADDR_OFFSET);
+
+  // Read Volume ID
+  res = fat_read_single_block(pinfo->vol_begin_addr, buffer);
+  if (0 != res) {
+    errno = EIO;
+    return FAT_FAIL;
+  }
+
+  // General FAT
+  pinfo->bytes_per_sector    = fat_get_uint16(buffer + 11);
+  pinfo->sectors_per_cluster = fat_get_uint8(buffer + 13);
+  pinfo->num_res_sectors     = fat_get_uint16(buffer + 14);
+  pinfo->num_fats            = fat_get_uint8(buffer + 16);
+  pinfo->num_dir_entries     = fat_get_uint16(buffer + 17);
+  pinfo->num_total_sectors   = fat_get_uint16(buffer + 19);
+  pinfo->media_desc_type     = fat_get_uint8(buffer + 21);
+  pinfo->sectors_per_fat     = fat_get_uint16(buffer + 22);
+
+  // FAT32 only
+  pinfo->sectors_per_fat    = fat_get_uint32(buffer + 0x24);
+  pinfo->root_dir_cluster   = fat_get_uint32(buffer + 0x2C);
+
+  // Derived
+  pinfo->entries_per_sector = pinfo->bytes_per_sector / FAT_DIR_ENTRY_WIDTH;
+  pinfo->fat_begin_addr     = pinfo->vol_begin_addr + pinfo->num_res_sectors;
+  pinfo->cluster_begin_addr = pinfo->fat_begin_addr +
+    (pinfo->num_fats * pinfo->sectors_per_fat);
+
+  // Calculate address of root dir
+  pinfo->root_dir_addr      = pinfo->cluster_begin_addr +
+    (pinfo->root_dir_cluster - 2) * pinfo->sectors_per_cluster;
+
+  errno = 0;
+  return FAT_SUCCESS;
+}
+
+// Finds the index in path of the next path delimiter or EOL
+uint32_t fat_idx_of_next_path_delim(uint8_t *path, uint32_t start) {
+  uint32_t next = start;
+  for (next = start; 1; ++next) {
+    if (path[next] == 0 || path[next] == '\\' || path[next] == '/' ||
+        path[next] == 0x20) { // Present in FAT32 names
+      break;
+    }
+  }
+  return next;
+}
+
+// Retrieves the cluster of directory entry in a read sector.
+inline uint32_t fat_cluster_of_dir_entry(uint8_t *sector, uint32_t entry_idx) {
+  uint32_t high = fat_get_uint16(sector + entry_idx * FAT_DIR_ENTRY_WIDTH + 0x14);
+  uint32_t low = fat_get_uint16(sector + entry_idx * FAT_DIR_ENTRY_WIDTH + 0x1a);
+  return low | (high << 16);
+}
+
+// Retrieves the size of directory entry target in a read sector.
+inline uint32_t fat_size_of_dir_entry(uint8_t *sector, uint32_t entry_idx) {
+  return fat_get_uint32(sector + entry_idx * FAT_DIR_ENTRY_WIDTH + 0x1C);
+}
+
+// Reads entry from the FAT corresponding to cluster.
+// Negative numbers are errors
+int fat_get_table_value(uint32_t cluster, uint32_t *tv) {
+  uint8_t buffer[fat_pinfo.bytes_per_sector]; // Should be 512
+
+  uint32_t idx = cluster * 4; // 4 bytes for every entry
+  uint32_t sec = fat_pinfo.fat_begin_addr +
+    (idx / fat_pinfo.bytes_per_sector); // Sector containing entry
+  uint32_t entry_idx = idx % fat_pinfo.bytes_per_sector; // Index in sector
+
+  // Read sector of FAT
+  if (0 != fat_read_single_block(sec, buffer)) {
+    return FAT_FAIL;
+  }
+
+  *tv = fat_get_uint32(buffer + entry_idx) & 0x0FFFFFFF; // Ignore high 4 bits
+  return FAT_SUCCESS;
+}
+
+// Compares part of a path name to the name belong to an entry (chain)
+// Updates cdidx to short entry
+int fat_compare_entry_name(const char *path, int pmin, int pmax,
+                           uint8_t *sector, FatDirEntryIdx *cdidx)
+{
+  int k = 0;
+
+  if (FAT_SUCCESS == fat_get_long_name_uint8(sector, cdidx, long_name8)) {
+    int32_t entry_len = fat_idx_of_next_path_delim(long_name8, 0);
+    int32_t part_len = pmax - pmin;
+
+    // Check every character individually
+    if (entry_len != part_len) {
+      return FAT_FAIL;
+    }
+    for (k = 0; k < entry_len; k++) {
+      if (toupper(long_name8[k]) != toupper(path[pmin + k])) {
+        return FAT_FAIL;
+      }
+    }
+    if (k != entry_len) { // Mismatch == early termination
+      return FAT_FAIL;
+    }
+
+    return FAT_SUCCESS;
+  }
+
+  return FAT_FAIL;
+}
+
+
+/*! Opens a file for a dir entry in a sector
+  Returns fd in case of success
+  Returns -1 in case of failure
+  fd is index into fat_open_files, but is offset by FAT_FD_OFFSET
+  to avoid clashing with fds for stdout / stdin / stderr
+*/
+int fat_open_dir_entry(uint8_t *sector, FatDirEntryIdx *entry_idx) {
+  int fd = -1;
+
+  int i;
+  for (i = 0; i < FAT_MAX_FILES; ++i) {
+    if (0 == fat_open_files[i].free) {
+      continue;
+    }
+
+    FatFile *f = &fat_open_files[i];
+    f->free = 0;
+    f->pos = 0;
+    f->dir_idx = *entry_idx;
+    f->start_cluster = fat_cluster_of_dir_entry(sector, entry_idx->index);
+    f->current_cluster = f->start_cluster;
+    f->size = fat_size_of_dir_entry(sector, entry_idx->index);
+    fd = i;
+    break;
+  }
+
+  if (fd == -1) {
+    return -1;
+  }
+
+  return fd + FAT_FD_OFFSET;
+}
+
+// TODO: Handle possible loops in this return values.
+// A loop in FAT entry link could cause an endless loop.
+int fat_acquire_next_cluster(uint32_t *cluster, int link_to_new) {
+  uint32_t tv = 0;
+  if (FAT_SUCCESS != fat_get_table_value(*cluster, &tv)) {
+    return FAT_FAIL;
+  }
+  else if (FAT_TV_BAD(tv)) {
+    errno = EBADF;
+    return FAT_FAIL;
+  }
+  else if (FAT_TV_FREE(tv)) {
+    //printf("Error: Cluster %ld is marked as free!\n", *cluster);
+    errno = EBADF;
+    return FAT_FAIL;
+  }
+  else if (!FAT_TV_LAST(tv)) {
+    *cluster = tv;
+    return FAT_SUCCESS;
+  }
+
+  // Search for next cluster
+  uint32_t fat_start = fat_pinfo.fat_begin_addr;
+  uint32_t secsz = fat_pinfo.bytes_per_sector;
+  uint32_t entries_per_sector = secsz / 4;
+  uint8_t buf[secsz]; // Should be 512
+
+  uint32_t ent_idx_in_fat_start = *cluster;
+  uint32_t ent_idx_in_sec_start = ent_idx_in_fat_start % entries_per_sector;
+  uint32_t cur_ent_in_sec = ent_idx_in_sec_start;
+
+  uint32_t sec_off_start = ent_idx_in_fat_start / entries_per_sector;
+  uint32_t cur_sec_in_fat = fat_start + sec_off_start;
+  uint32_t cur_ent_in_fat = 0;
+
+  // Copy sector containing current entry, for modification to the FAT
+  uint8_t orig_sec[secsz];
+  if (FAT_SUCCESS != fat_read_single_block(cur_sec_in_fat, orig_sec)) {
+    //printf("Fail Read Acquire Original\n"); // TODO: Remove
+    return FAT_FAIL;
+  }
+
+  uint32_t i = 0; // Sector offset
+  uint32_t j = 0; // Entry offset
+  for (i = 0; i < fat_pinfo.sectors_per_fat; i++) {
+    cur_sec_in_fat = (sec_off_start + i) % fat_pinfo.sectors_per_fat;
+
+    // Read sector we are currently searching
+    if (FAT_SUCCESS != fat_read_single_block(fat_start + cur_sec_in_fat, buf)) {
+      //printf("Fail Read Acquire 1\n"); // TODO: Remove
+      return FAT_FAIL;
+    }
+
+    // Loop through entries
+    for (j = 0; j < entries_per_sector; j++) { // j is the entry index in cur_sec_in_fat
+      cur_ent_in_sec = (ent_idx_in_sec_start + j) % entries_per_sector;
+      cur_ent_in_fat = cur_sec_in_fat * entries_per_sector + cur_ent_in_sec;
+      tv = fat_get_uint32(buf + 4 * cur_ent_in_sec) & 0x0FFFFFFF; // Ignore high 4 bits
+
+      if (FAT_TV_BAD(tv)) {
+        continue;
+      }
+      if (FAT_TV_LAST(tv)) {
+        continue;
+      }
+      if (!FAT_TV_FREE(tv)) {
+        continue;
+      }
+
+      // The table entry is free
+      uint32_t next_cluster = cur_ent_in_fat;
+      if (next_cluster == 0) // TODO: Avoid this by altering the calculation
+        continue;
+      *cluster = next_cluster;
+
+      // Change values in FAT
+      if (link_to_new) {
+        // If the entry is in the same sector, we must point to the new cluster in
+        // the read buffer, or else the change will be overwritten by the second write.
+        uint8_t *mark_next_buf = sec_off_start == cur_sec_in_fat ? buf : orig_sec;
+
+        // Link old entry to new
+        fat_set_uint32(next_cluster,  mark_next_buf + 4 * ent_idx_in_sec_start);
+        if (FAT_SUCCESS !=
+            fat_write_single_block(fat_start + sec_off_start, mark_next_buf)) {
+          return FAT_FAIL;
+        }
+      }
+
+      // Mark new last cluster as last
+      fat_set_uint32(0x0FFFFFFF, buf + 4 * cur_ent_in_sec);
+      if (FAT_SUCCESS != fat_write_single_block(fat_start + cur_sec_in_fat, buf)) {
+        return FAT_FAIL;
+      }
+
+      return FAT_SUCCESS;
+    }
+  }
+
+  errno = ENOSPC;
+  return FAT_FAIL;
+}
+
+/*! Resolves path to a directory entry. Loads containing sector into sector.
+  Returns FAT_SUCCESS or FAT_FAILURE.
+  Sets errno.
+*/
+int fat_resolve_path(const char *path, uint8_t *sector, FatDirEntryIdx *dir_idx) {
+  uint32_t current_cluster = fat_pinfo.root_dir_cluster;
+  uint32_t current_start_sector = fat_pinfo.root_dir_addr;
+
+  uint32_t entries_per_sector = fat_pinfo.bytes_per_sector / FAT_DIR_ENTRY_WIDTH;
+
+  int pmin = 0; // Start of current path part
+  int pmax = 0; // End of current path part
+
+  int exhausted_dir = 0;
+  int found_dir_in_cluster = 0;
+
+  FatDirEntryIdx cdidx = *dir_idx;
+
+  while (!exhausted_dir) {
+    // Search forward for pmax
+    pmax = fat_idx_of_next_path_delim((uint8_t *)path, pmin);
+
+    while (!exhausted_dir) {
+      cdidx.cluster = current_cluster;
+      current_start_sector = fat_first_sector_of_cluster(current_cluster);
+
+      // Check cluster for entry
+      for (cdidx.sector = 0; cdidx.sector < fat_pinfo.sectors_per_cluster; cdidx.sector++) {
+        fat_read_single_block(current_start_sector + cdidx.sector, sector); // TODO: Handle error
+
+        // Check sector for entry
+        for (cdidx.index = 0; cdidx.index < entries_per_sector; cdidx.index++) {
+
+          if (FAT_SUCCESS ==
+              fat_compare_entry_name(path, pmin, pmax, sector, &cdidx)) {
+            found_dir_in_cluster = 1;
+            break;
+          }
+        }
+
+        if (1 == found_dir_in_cluster) {
+          break;
+        }
+      }
+
+      if (!found_dir_in_cluster) {
+        uint32_t tv = 0;
+        if (FAT_SUCCESS != fat_get_table_value(current_cluster, &tv)) {
+          exhausted_dir = 1; // TODO: Try again? Set errno?
+        }
+        else if (FAT_TV_LAST(tv)) {
+          exhausted_dir = 1;
+        }
+        else if (FAT_TV_BAD(tv)) {
+          exhausted_dir = 1; // TODO: Check next cluster maybe?
+        }
+        else {
+          current_cluster = tv;
+        }
+      }
+      else { // found_dir_in_cluster
+        uint8_t isdir = FAT_DIRECTORY &
+          fat_attrib_of_dir_entry(sector, cdidx.index);
+
+        if (0 != path[pmax]) { // Not at last path segment
+          if (!isdir) {
+            errno = ENOTDIR;
+            return FAT_FAIL;
+          }
+        }
+        else { // At last path segment
+          *dir_idx = cdidx;
+          errno = 0;
+          return FAT_SUCCESS;
+        }
+
+        // Don't update current_sector
+        pmin = pmax + 1;
+        pmax = pmin;
+        found_dir_in_cluster = 0; // Search again
+        current_cluster = fat_cluster_of_dir_entry(sector, cdidx.index);
+        break;
+      }
+    }
+  }
+
+  errno = ENOENT;
+  return FAT_FAIL;
+}
+
+/* Frees all cluster in the cluster chain.
+  Returns FAT_SUCCESS or FAT_FAILURE.
+  Sets errno.
+*/
+int fat_free_cluster_chain(const uint32_t start_cluster) {
+  uint32_t secsz = fat_pinfo.bytes_per_sector;
+  uint8_t buf[secsz];
+
+  uint32_t tv = start_cluster;
+  uint32_t byteoff = 0;
+  uint32_t secoff = 0;
+  uint32_t sec = 0;
+  uint32_t byteoff_in_sec = 0;
+
+  // TODO: Only read / write buf when reaching a new one
+  errno = 0;
+  do {
+    // Update index
+    byteoff = tv * 4;
+    secoff = byteoff / fat_pinfo.bytes_per_sector;
+    sec = fat_pinfo.fat_begin_addr + secoff;
+    byteoff_in_sec = byteoff % secsz;
+
+    // Load in buf
+    if (FAT_SUCCESS != fat_read_single_block(sec, buf)) {
+      break;
+    }
+
+    // Retrieve and verify table value
+    tv = fat_get_uint32(buf + byteoff_in_sec) & 0x0FFFFFFF;
+    if (FAT_TV_BAD(tv)) {
+      errno = EBADF;
+      break;
+    }
+    else if (FAT_TV_FREE(tv)) {
+      errno = EBADF;
+      break;
+    }
+
+    // Free cluster
+    fat_set_uint32(0, buf + byteoff_in_sec);
+
+    // Write back
+    if (FAT_SUCCESS != fat_write_single_block(sec, buf)) {
+      break;
+    }
+  }
+  while (!FAT_TV_LAST(tv));
+
+  return errno == 0 ? FAT_SUCCESS : FAT_FAIL;
+}
+
+/*! Creates a new file or directory for the path, setting the file descriptor
+  Arguments: Path, index of parent dir, buffer, file descriptor, file or dir?
+  Directory index and buffer are assumed to set and loaded.
+  Sets errno.
+*/
+int fat_create(const char *path, FatDirEntryIdx *pdir_idx, uint8_t *sector, int *fd, const char isfile) {
+
+  errno = 0;
+
+  // Isolate the file from the rest of the path
+  uint8_t delim = 0;
+  uint32_t pmin = 0;
+  uint32_t pmax = 0;
+  do {
+    pmax = fat_idx_of_next_path_delim((uint8_t *)path, pmin);
+    delim = path[pmax];
+    if (delim == 0) { // Search until end of path
+      break; // pmin is now index of first character in file name
+    }
+    pmin = pmax + 1;
+  } while (delim != 0); // Just a fallback if above is altered
+
+  // Check that the parent directory exists
+  char dir_path[pmin]; // Can contain first part + delim + 0
+  memcpy(dir_path, path, pmin);
+  dir_path[pmin] = 0; // Cap path
+  if (dir_path[pmin - 1]) {
+    dir_path[pmin - 1] = 0; // TODO: resolve_path should make this unnecesary
+  }
+
+  // Find parent dir, if it is not root
+  int path_resolved = 0;
+  if (pmin == 0) {
+    path_resolved = 1;
+    pdir_idx->cluster = fat_pinfo.root_dir_cluster;
+  }
+  else if (FAT_SUCCESS == fat_resolve_path(dir_path, sector, pdir_idx)) {
+    path_resolved = 1;
+    pdir_idx->cluster = fat_cluster_of_dir_entry(sector, pdir_idx->index);
+  }
+
+  if (path_resolved) {
+    pdir_idx->sector = pdir_idx->index = 0; // Only cluster is needed
+
+    uint32_t i = 0;
+    uint32_t j = 0;
+    uint32_t k = 0;
+
+    // Find file extension
+    uint32_t name_len_total = pmax - pmin; // Length of file name + extension
+    uint32_t name_len = name_len_total;
+    uint32_t extension_len = 0;
+    int32_t last_dot_idx = -1;
+    for (i = 0; i < name_len_total; ++i) {
+      if (path[pmax - 1 - i] == '.') {
+        last_dot_idx = pmax - 1 - i;
+      }
+    }
+    if (last_dot_idx > 0) {
+      name_len = last_dot_idx - pmin;
+      extension_len = name_len_total - name_len - 1; // Adjust for dot in total name
+    }
+
+    // Calculate directory entries needed to store name
+    uint32_t req_entries = 1;
+    if (name_len > 8 || extension_len > 3) { // Long name needed
+      req_entries += name_len_total / 13;
+      if (name_len_total % 13 != 0) {
+        req_entries++;
+      }
+    }
+
+    // Copy file name over
+    char fname_short[8 + 3]; // Name and filetype
+    for (i = 0; i < 11; i++) {
+      fname_short[i] = 0x20; // Filler byte in FAT
+    }
+
+    uint32_t copied = 0;
+    for (i = 0; i < name_len; ++i) {
+      char c = path[pmin + i];
+      if (copied < 8 && c != ' ' && c != '.') { // Strip all spaces and periods
+        fname_short[copied] = toupper(c);
+        copied++;
+      }
+    }
+
+    // Copy file ending if it exists
+    if (last_dot_idx > 0) {
+      for (i = 0; i < 3; i++) {
+        fname_short[8 + i] = toupper(path[last_dot_idx + 1 + i]);
+      }
+    }
+
+    // Search until end of directory doing:
+    //   1. Find place for entry that has space for long name entries before it
+    //   2. Find lowest possible short name number
+    uint32_t empty_entries_seen = 0; // Number of free entries seen in a row
+    FatDirEntryIdx target_dir_idx; // Final index of the main directory entry
+
+    uint32_t current_cluster = pdir_idx->cluster;
+    uint32_t current_start_sector = fat_first_sector_of_cluster(current_cluster);
+    uint32_t entries_per_sector = fat_pinfo.bytes_per_sector / FAT_DIR_ENTRY_WIDTH;
+    uint8_t *ent = 0;
+
+    // Store the index of the first entry in the chain of long entries
+    // This makes writing them easier, since the FAT is singly-linked
+    FatDirEntryIdx first_dir_idx;
+    first_dir_idx.cluster = current_cluster;
+    first_dir_idx.sector = 0;
+    first_dir_idx.index = 0;
+
+    // Number of collisions on the short name
+    uint32_t short_name_nums[12];
+    for (i = 0; i < 12; ++i) {
+      short_name_nums[i] = 0;
+    }
+
+    int done_searching = 0;
+    int reached_last = 0;
+    int found_index = 0;
+    while (!done_searching) {
+      current_start_sector = fat_first_sector_of_cluster(current_cluster);
+
+      // Check cluster for entry
+      for (i = 0; i < fat_pinfo.sectors_per_cluster; ++i) {
+        fat_read_single_block(current_start_sector + i, sector); // TODO: Handle error
+
+        // Check sector for entry
+        for (j = 0; j < entries_per_sector; ++j) {
+          ent = sector + FAT_DIR_ENTRY_WIDTH * j;
+
+          reached_last |= FAT_DIR_ENTRY_LAST == ent[0];
+          if (reached_last || ent[0] == FAT_DIR_ENTRY_FREE) {
+            // If the last entry in the folder has been reached
+            // we could begin jumping whole sectors ahead, as we
+            // know they must be free. This is not done however.
+
+            // Empty entry, check for space
+            empty_entries_seen++;
+            if (!found_index) {
+              if (empty_entries_seen == 1) {
+                first_dir_idx.cluster = current_cluster;
+                first_dir_idx.sector = i;
+                first_dir_idx.index = j;
+              }
+              if (empty_entries_seen >= req_entries) {
+                found_index = 1;
+                target_dir_idx.cluster = current_cluster;
+                target_dir_idx.sector = i;
+                target_dir_idx.index = j;
+              }
+            }
+          }
+          else { // An occupied entry
+            empty_entries_seen = 0;
+
+            // Check short name collision
+            if (ent[11] != FAT_LONG_NAME_ENTRY) {
+              short_name_nums[0]++;
+              for (k = 0; k < 11; ++k) {
+                if (toupper(fname_short[k]) == toupper(ent[k])) {
+                  short_name_nums[k+1]++;
+                }
+                else {
+                  break;
+                }
+              }
+
+              if (k == 11) { // Collision
+                errno = EEXIST;
+                done_searching = 1;
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      if (found_index) {
+        break;
+      }
+
+      // At end of cluster, so find next, extending folder if necessary
+      if (FAT_SUCCESS != fat_acquire_next_cluster(&current_cluster, 1)) {
+        // Keep errno from acquire_next
+        done_searching = 1;
+        break;
+      }
+
+      // Long entry chains are always contiguous in memory, so when jumping
+      // clusters restart our entry counting.
+      empty_entries_seen = 0;
+
+      // We need to make remove any entries marked as last, to have the next
+      // cluster be reachable. This only needs to happen when reaching a new cluster,
+      // as otherwise they would be overwritten by the chain itself.
+      if (reached_last) {
+        uint32_t tail_entries = entries_per_sector - first_dir_idx.index;
+        for (j = 0; j < tail_entries; j++) {
+          ent = sector + FAT_DIR_ENTRY_WIDTH * (first_dir_idx.index + j);
+          ent[0] = FAT_DIR_ENTRY_FREE;
+        }
+        assert(first_dir_idx.sector == fat_pinfo.sectors_per_cluster - 1);
+        if (FAT_SUCCESS != fat_write_single_block(current_start_sector +
+                                                  first_dir_idx.sector, sector)) {
+          // Keep errno from write
+          break;
+        }
+      }
+    }
+
+    if (errno != 0) {
+      // Just keep errno, skipping further error checking
+    }
+    else if (!found_index) {
+      errno = ENOSPC;
+    }
+    else if (req_entries == 1 && pmax >= FAT_MAX_SHORT_PATH) {
+      errno = ENAMETOOLONG;
+    }
+    else if (req_entries >= 2 && (pmax >= FAT_MAX_LONG_PATH ||
+                                  name_len_total >= FAT_MAX_LONG_NAME)) {
+      errno = ENAMETOOLONG;
+    }
+    else {
+      // Add tail to short name if needed
+      uint32_t short_chars_max = 10;
+      int32_t short_name_chars = req_entries > 1 ? 6 : 8;
+      short_name_chars = umin(name_len, short_name_chars);
+      while (short_name_chars >= 0 &&
+            short_name_nums[short_name_chars] + 1 >= short_chars_max) {
+        short_name_chars--;
+        short_chars_max *= 10;
+      }
+
+      // Add tail to long name entries
+      if (req_entries > 1) {
+        fname_short[short_name_chars] = '~';
+        sprintf(fname_short + short_name_chars + 1, "%ld",
+                1 + short_name_nums[short_name_chars]);
+
+        // Copy extension back
+        // TODO: Why is it removed?
+        if (last_dot_idx > 0) {
+          for (i = 0; i < 3; i++) {
+            fname_short[8 + i] = toupper(path[last_dot_idx + 1 + i]);
+          }
+        }
+      }
+
+      uint32_t en = req_entries; // Current entry number. Short = 1. Next = 0.
+      uint32_t ord = req_entries - 1;
+
+      // Begin writing from the start of the chain
+      uint32_t cur_cluster = first_dir_idx.cluster;
+      uint32_t cur_sec_off = first_dir_idx.sector;
+      uint32_t cur_sec_start = fat_first_sector_of_cluster(cur_cluster);
+      uint32_t cur_ent_off = first_dir_idx.index;
+
+      // Calculate checksum from short name
+      uint8_t checksum = 0;
+      for (i = 0; i < 11; i++) {
+        checksum = (checksum >> 1) + (checksum << 7); // Rotate right
+        checksum += fname_short[i];
+      }
+
+      // Get new cluster, marking in FAT
+      uint32_t new_cluster = target_dir_idx.cluster;
+      if (FAT_SUCCESS != fat_acquire_next_cluster(&new_cluster, 0)) {
+        // TODO: Error handling
+      }
+
+      // Offset in path when writing long entries
+      uint32_t path_off = pmax + (13 - (name_len_total % 13)) - 13;
+      if (name_len_total % 13 == 0) {
+        path_off -= 13;
+      }
+
+      // Read the sector containing the start of the chain
+      /*
+      if (target_dir_idx.sector != first_dir_idx.sector) {
+        fat_read_single_block(cur_sec_start + cur_sec_off, sector); // TODO: Error handling
+      }
+      */
+      fat_read_single_block(cur_sec_start + cur_sec_off, sector); // TODO: Error handling
+
+      // Start writing
+      while (en <= req_entries && errno == 0) {
+        ent = sector + FAT_DIR_ENTRY_WIDTH * cur_ent_off;
+
+        // TODO: Organize cases in order of: Long -> Short -> Last
+
+        if (en == 1) { // Short entry
+          memcpy(ent, fname_short, 11); // Name
+
+          // Attribute (ARCHIVE set on creation)
+          uint8_t attrib = FAT_ARCHIVE | (isfile ? 0 : FAT_DIRECTORY);
+          fat_set_uint8(attrib, ent + 11);
+
+          // We set all time values to zero, as there is no time setup
+          fat_set_uint8(0, ent + 13); // Create time tenth
+          fat_set_uint16(0, ent + 14); // Create time
+          fat_set_uint16(0, ent + 16); // Create date
+          fat_set_uint16(0, ent + 18); // Last access date
+          fat_set_uint16(0, ent + 22); // Write time
+          fat_set_uint16(0, ent + 24); // Write date
+
+          fat_set_uint16(new_cluster >> 16, ent + 20); // High word of cluster
+          fat_set_uint16(new_cluster, ent + 26); // Low word of cluster
+          fat_set_uint32(0, ent + 28); // File size
+
+          // Get file descriptor
+          if (isfile) {
+            *fd = fat_open_dir_entry(sector, &target_dir_idx); // Get file descriptor
+          }
+          else {
+            pdir_idx->cluster = new_cluster; // Needed in mkdir
+          }
+        }
+        else if (en >= 2) { // Long entries
+          ord = en - 1;
+          if (ord == req_entries - 1) {
+            ord |= FAT_LAST_LONG; // Mark physical first as last in long name chain
+          }
+          fat_set_uint8(ord, ent + 0); // Ordinal
+          fat_set_uint8(FAT_LONG_NAME_ENTRY, ent + 11); // Attribute
+          fat_set_uint8(0, ent + 12); // Type (long sub-entry)
+          fat_set_uint8(checksum, ent + 13); // Checksum
+          fat_set_uint16(0, ent + 26); // First Cluster Low (always zero)
+
+          // Set name
+          uint16_t v = 0;
+          for (i = 0; i < 5; ++i) { // Char 0-4
+            v = path_off > pmax ? 0xFFFF : path_off == pmax ? 0 : path[path_off];
+            fat_set_uint16(v, ent + 1 + 2*i);
+            path_off++;
+          }
+          for (i = 0; i < 6; ++i) { // Char 5-10
+            v = path_off > pmax ? 0xFFFF : path_off == pmax ? 0 : path[path_off];
+            fat_set_uint16(v, ent + 14 + 2*i);
+            path_off++;
+          }
+          for (i = 0; i < 2; ++i) { // Char 11-12
+            v = path_off > pmax ? 0xFFFF : path_off == pmax ? 0 : path[path_off];
+            fat_set_uint16(v, ent + 28 + 2*i);
+            path_off++;
+          }
+          path_off -= 2*13;
+        }
+        else if (en == 0) { // Reached entry following the short entry
+          // Mark the following entry as last in folder, if it is
+          if (reached_last) {
+            ent[0] = FAT_DIR_ENTRY_LAST;
+          }
+
+          fat_write_single_block(cur_sec_start + cur_sec_off, sector); // Done writing
+          break; // No need to update offsets anymore
+        }
+
+        // Check if new sector is reached
+        cur_ent_off++;
+        if (cur_ent_off >= entries_per_sector) {
+          // Write sector
+          fat_write_single_block(cur_sec_start + cur_sec_off, sector);
+
+          cur_ent_off = 0;
+          cur_sec_off++;
+          if (cur_sec_off >= fat_pinfo.sectors_per_cluster) {
+            if (FAT_SUCCESS == fat_acquire_next_cluster(&cur_cluster, 0)) {
+              cur_sec_start = fat_first_sector_of_cluster(cur_cluster);
+              cur_sec_off = 0;
+            }
+            else {
+              // TODO: Error handling
+            }
+          }
+
+          // Read new sector
+          fat_read_single_block(cur_sec_start + cur_sec_off, sector);
+        }
+
+        // Next entry
+        en--;
+      }
+    }
+  }
+
+  // Keep errno from earlier failure
+
+  return errno == 0 ? FAT_SUCCESS : FAT_FAIL;
+}
+
+// Deletes and unlinks a directory entry
+int fat_delete(const char *path, uint8_t *sector) {
+  errno = 0;
+
+  // Isolate the file from the rest of the path
+  uint8_t delim = 0;
+  uint32_t pmin = 0;
+  uint32_t pmax = 0;
+  do {
+    pmax = fat_idx_of_next_path_delim((uint8_t *)path, pmin);
+    delim = path[pmax];
+    if (delim == 0) { // Search until end of path
+      break; // pmin is now index of first character in file name
+    }
+    pmin = pmax + 1;
+  } while (delim != 0); // Just a fallback if above is altered
+
+  // Check that the parent directory exists
+  char dir_path[pmin]; // Can contain first part + delim + 0
+  memcpy(dir_path, path, pmin);
+  dir_path[pmin] = 0; // Cap path
+  if (dir_path[pmin - 1]) {
+    dir_path[pmin - 1] = 0; // TODO: resolve_path should make this unnecesary
+  }
+
+  // Find parent dir, if it is not root
+  FatDirEntryIdx pdir_idx;
+  int path_resolved = 0;
+  if (pmin == 0) {
+    path_resolved = 1;
+    pdir_idx.cluster = fat_pinfo.root_dir_cluster;
+  }
+  else if (FAT_SUCCESS == fat_resolve_path(dir_path, sector, &pdir_idx)) {
+    path_resolved = 1;
+    pdir_idx.cluster = fat_cluster_of_dir_entry(sector, pdir_idx.index);
+  }
+
+  if (path_resolved) {
+
+    // Search until file has been found either:
+    //   1. End of directory
+    //   2. Next non-empty entry
+    // Everything in between will be cleared
+    uint32_t empty_entries_seen = 0; // Number of free entries seen in a row
+    FatDirEntryIdx target_dir_idx; // Last index
+
+    FatDirEntryIdx cidx;
+    cidx.cluster = pdir_idx.cluster;
+    cidx.sector = 0;
+    cidx.index = 0;
+
+    uint32_t current_start_sector = fat_first_sector_of_cluster(cidx.cluster);
+    uint32_t entries_per_sector = fat_pinfo.bytes_per_sector / FAT_DIR_ENTRY_WIDTH;
+    uint8_t *ent = 0;
+
+    // Index of first empty entry in streak before target entry
+    FatDirEntryIdx first_empty_idx;
+    first_empty_idx.cluster = cidx.cluster;
+    first_empty_idx.sector = 0;
+    first_empty_idx.index = 0;
+
+    // Index of first empty entry in streak before target entry
+    FatDirEntryIdx first_target_idx;
+
+    uint32_t initial_cluster = 0;
+
+    int found_entry = 0;
+    int found_next = 0;
+    int done_searching = 0;
+    int reached_last = 0;
+    while (!done_searching) {
+      current_start_sector = fat_first_sector_of_cluster(cidx.cluster);
+
+      // Check cluster for entry
+      for (cidx.sector = 0; cidx.sector < fat_pinfo.sectors_per_cluster; cidx.sector++) {
+        fat_read_single_block(current_start_sector + cidx.sector, sector);
+
+        // Check sector for entry
+        for (cidx.index = 0; cidx.index < entries_per_sector; ++cidx.index) {
+          ent = sector + FAT_DIR_ENTRY_WIDTH * cidx.index;
+
+          reached_last |= FAT_DIR_ENTRY_LAST == ent[0];
+          if (ent[0] == FAT_DIR_ENTRY_FREE) {
+            // Empty entry, check for space
+            empty_entries_seen++;
+            if (empty_entries_seen == 1) {
+              first_empty_idx = cidx;
+            }
+          }
+          else {
+            if (!found_entry) {
+              // Store this now since the name retrieval updates the idx
+              first_target_idx = cidx;
+
+              // Check name
+              if (FAT_SUCCESS == fat_compare_entry_name(path, pmin, pmax, sector, &cidx)) {
+                target_dir_idx = cidx;
+                found_entry = 1;
+
+                // Extract initial cluster
+                initial_cluster = fat_cluster_of_dir_entry(sector, cidx.index);
+              }
+              else {
+                empty_entries_seen = 0;
+              }
+            }
+            else {
+              found_next = 1;
+              break;
+            }
+          }
+
+          if (found_next || reached_last) {
+            break;
+          }
+        }
+        if (found_next || reached_last) {
+          break;
+        }
+      }
+
+      if (reached_last || (found_entry && found_next)) {
+        break;
+      }
+
+      // At end of cluster, so find next
+      if (FAT_SUCCESS != fat_acquire_next_cluster(&cidx.cluster, 0)) {
+        // Keep errno from acquire_next
+        done_searching = 1;
+        break;
+      }
+    }
+
+    if (errno != 0) {
+      // Just keep errno, skipping further error checking
+    }
+    else if (!found_entry) {
+      errno = ENOENT;
+    }
+    else if (initial_cluster == 0 || // A completely empty file can have no cluster attached
+             FAT_SUCCESS == fat_free_cluster_chain(initial_cluster)) {
+      if (reached_last && empty_entries_seen > 0) {
+        // This entry is the last non-empty in the directory
+        uint32_t sec_addr = fat_first_sector_of_cluster(first_empty_idx.cluster) +
+          first_empty_idx.sector;
+
+        fat_read_single_block(sec_addr, sector);
+        fat_set_uint8(FAT_DIR_ENTRY_LAST, sector + first_empty_idx.index * FAT_DIR_ENTRY_WIDTH);
+        fat_write_single_block(sec_addr, sector);
+      }
+      else {
+        // Begin writing from the start of the chain
+        uint32_t cur_cluster = first_target_idx.cluster;
+        uint32_t cur_sec_off = first_target_idx.sector;
+        uint32_t cur_sec_start = fat_first_sector_of_cluster(cur_cluster);
+        uint32_t cur_ent_off = first_target_idx.index;
+
+        uint8_t mark = reached_last ? FAT_DIR_ENTRY_LAST : FAT_DIR_ENTRY_FREE;
+
+        fat_read_single_block(cur_sec_start + cur_sec_off, sector);
+
+        // Start writing
+        while (errno == 0) {
+          ent = sector + FAT_DIR_ENTRY_WIDTH * cur_ent_off;
+
+          int done = (cur_cluster == target_dir_idx.cluster &&
+                      cur_sec_off == target_dir_idx.sector &&
+                      cur_ent_off == target_dir_idx.index);
+
+          // Mark entry
+          fat_set_uint8(mark, ent);
+          if (done) {
+            fat_write_single_block(cur_sec_start + cur_sec_off, sector);
+            break;
+          }
+
+          // Check if new sector is reached
+          cur_ent_off++;
+          if (cur_ent_off >= entries_per_sector) {
+            // Write sector
+            fat_write_single_block(cur_sec_start + cur_sec_off, sector);
+
+            cur_ent_off = 0;
+            cur_sec_off++;
+            if (cur_sec_off >= fat_pinfo.sectors_per_cluster) {
+              if (FAT_SUCCESS == fat_acquire_next_cluster(&cur_cluster, 0)) {
+                cur_sec_start = fat_first_sector_of_cluster(cur_cluster);
+                cur_sec_off = 0;
+              }
+              else {
+                // TODO: Error handling
+              }
+            }
+
+            // Read new sector
+            fat_read_single_block(cur_sec_start + cur_sec_off, sector);
+          }
+        }
+      }
+    }
+  }
+
+  // Keep errno from earlier failure
+
+  return errno == 0 ? FAT_SUCCESS : FAT_FAIL;
+}
+
+// --- Interface ---
+
+/* Initializes fat32 module.
+   This must be done before any calls to other fat32 functions.
+   Returns 0 on success, -1 on failure.
+
+   Sets errno == EPERM if already initialized.
+   Sets errno == EIO if a bad response in received from disk.
+ */
+int fat_init(const FatPartitionInfo *pinfo) {
+  if (fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  // Set the global partition info
+  fat_pinfo = *pinfo;
+
+  // Initialize open files
+  int i;
+  for (i = 0; i < FAT_MAX_FILES; ++i) {
+    fat_open_files[i].free = 1;
+    fat_open_files[i].pos = 0;
+  }
+
+  fat_initialized = 1;
+
+  errno = 0;
+  return FAT_SUCCESS;
+}
+
+/*! Opens a file.
+    Returns the file descriptor of the opened file or -1 in case of failure.
+    Ignores read / write permissions.
+
+    Sets errno == EPERM if the module is not initialized.
+    Sets errno == ENOENT if the file can not be found.
+    Sets errno == EMFILE if the maximum number of open files is reached.
+    Sets errno == EEXIST if file exists and O_CREAT and O_EXCL is set.
+ */
+int fat_open(const char *path, int oflag) {
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  int fd = -1;
+  uint8_t sector[fat_pinfo.bytes_per_sector];
+  FatDirEntryIdx dir_idx;
+  FatFile *f;
+
+  long target_pos = 0;
+
+  errno = 0;
+
+  // Check if file exists
+  if (FAT_SUCCESS == fat_resolve_path(path, sector, &dir_idx)) {
+    if (oflag & O_CREAT & O_EXCL) {
+      errno = EEXIST;
+    }
+    else {
+      fd = fat_open_dir_entry(sector, &dir_idx);
+      if (fd < 0) {
+        errno = EMFILE;
+      }
+      else if (FAT_DIRECTORY & fat_attrib_of_dir_entry(sector, dir_idx.index)) {
+        errno = EISDIR;
+      }
+      else {
+        f = &fat_open_files[fd - FAT_FD_OFFSET];
+
+        if (oflag & O_TRUNC) {
+          uint32_t cluster = fat_cluster_of_dir_entry(sector, dir_idx.index);
+          uint32_t next_tv = 0;
+          if (FAT_SUCCESS == fat_get_table_value(cluster, &next_tv) &&
+              !FAT_TV_BAD(next_tv) && !FAT_TV_FREE(next_tv) &&
+              (FAT_TV_LAST(next_tv) || // If either the chain is just one cluster
+               FAT_SUCCESS == fat_free_cluster_chain(next_tv))) { // Or we cleared it
+
+              // Adjust size
+              f->size = 0;
+              fat_set_uint32(0, sector + 28 + dir_idx.index * FAT_DIR_ENTRY_WIDTH);
+
+              // Write back directory entry
+              uint32_t sec_addr = dir_idx.sector +
+                fat_first_sector_of_cluster(dir_idx.cluster);
+
+              fat_write_single_block(sec_addr, sector); // Keep errno on failure
+          }
+        }
+
+        target_pos = oflag & O_APPEND ? f->size : 0;
+      }
+    }
+  }
+  else if (oflag & O_CREAT) {
+    if (FAT_SUCCESS == fat_create(path, &dir_idx, sector, &fd, 1)) {
+      // Success
+    }
+    // Keep errno from fat_create
+  }
+
+  // Set the cursor
+  if (errno == 0) {
+    if (target_pos != fat_lseek(fd, target_pos, SEEK_SET)) {
+      //printf("Error seeking to %ld in %s (FD=%d)", target_pos, path, fd);
+    }
+  }
+
+  if (errno != 0 && fd > 0) {
+    fat_close(fd);
+    fd = -1;
+  }
+
+  return fd;
+}
+
+/*! Closes a file.
+    Returns 0 in case of success, -1 on failure.
+
+    Sets errno == EPERM if the module is not initialized.
+    Sets errno == EINVAL if the file descriptor is out of the valid range.
+    Sets errno == EBADF if the file descriptor does not match an open file.
+*/
+int fat_close(int fd) {
+  errno = 0;
+
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  if (fd < FAT_FD_OFFSET || fd >= FAT_FD_OFFSET + FAT_MAX_FILES) {
+    errno = EINVAL;
+    return FAT_FAIL;
+  }
+
+  FatFile *f = &fat_open_files[fd - FAT_FD_OFFSET];
+  if (f->free) {
+    errno = EBADF;
+    return FAT_FAIL;
+  }
+
+  // Closing is simply freeing the fd
+  f->free = 1;
+
+  errno = 0;
+  return FAT_SUCCESS;
+}
+
+/*! Write bytes to a file.
+    Returns the number of bytes written to the file, -1 in case of failure.
+*/
+int fat_write(int fd, uint8_t *buf, uint32_t sz) {
+  errno = 0;
+
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  if (fd < FAT_FD_OFFSET || fd >= FAT_FD_OFFSET + FAT_MAX_FILES) {
+    errno = EINVAL;
+    return FAT_FAIL;
+  }
+
+  FatFile *f = &fat_open_files[fd - FAT_FD_OFFSET];
+  if (f->free) {
+    errno = EBADF;
+    return FAT_FAIL;
+  }
+
+  // TODO: Acquire all needed clusters before writing.
+  // This is to minimize the amount of disk_read().
+
+  // TODO: Read block size from somewhere
+  uint32_t secsz = fat_pinfo.bytes_per_sector;
+  uint32_t bytes_written = 0;
+  uint8_t odd_buf[secsz];
+  uint8_t *wrbuf; // Where the next write is from
+
+  uint32_t secoff = (f->pos / secsz) % fat_pinfo.sectors_per_cluster;
+  uint32_t secfirst = fat_first_sector_of_cluster(f->current_cluster);
+  uint32_t sector = secfirst + secoff;
+
+  uint32_t byteoff = f->pos % secsz; // Offset from start of sector
+  uint32_t wrsz = 0; // Amount of bytes to write next iteration
+
+  errno = 0; // Set in loop if something goes wrong
+
+  while (sz > 0) {
+    wrsz = umin(secsz - byteoff, sz); // Start by writing up to next sector
+    sector = secfirst + secoff;
+
+    // If not a whole sector, we must read, change, write
+    if (wrsz < secsz) {
+      wrbuf = odd_buf; // Write from the odd buffer
+
+      // Read sector
+      if (FAT_SUCCESS != fat_read_single_block(sector, odd_buf)) {
+        break;
+      }
+
+      // Change value
+      memcpy(wrbuf + byteoff, buf + bytes_written, wrsz);
+    }
+    else {
+      wrbuf = buf + bytes_written;
+    }
+
+    // Write block
+    if (FAT_SUCCESS != fat_write_single_block(sector, wrbuf)) {
+      break;
+    }
+
+    // Update counters
+    bytes_written += wrsz;
+    sz -= wrsz;
+    if (byteoff + wrsz >= secsz) { // Update sector if end is reached
+      secoff++;
+      if (secoff >= fat_pinfo.sectors_per_cluster) {
+        if (FAT_SUCCESS != fat_acquire_next_cluster(&f->current_cluster, 1)) {
+          // Out of disk space
+          errno = ENOSPC;
+          break;
+        }
+
+        secoff = 0;
+        secfirst = fat_first_sector_of_cluster(f->current_cluster);
+      }
+    }
+
+    // No byte offset next write (can only happen in first iteration)
+    byteoff = 0; // Must happen here as it used in counter update
+  }
+
+  // Update size of file
+  // FIXME: Check this works with 4GB files
+  uint32_t new_size = f->pos + bytes_written;
+  if (new_size > f->size) {
+    sector = f->dir_idx.sector +
+      fat_first_sector_of_cluster(f->dir_idx.cluster);
+
+    if (FAT_SUCCESS != fat_read_single_block(sector, odd_buf)) {
+      //printf("Fail Read DirEntry\n"); // TODO: Remove
+    }
+    if (errno != EIO) {
+      fat_set_uint32(new_size,
+                     odd_buf + f->dir_idx.index * FAT_DIR_ENTRY_WIDTH + 0x1C);
+
+      if (FAT_SUCCESS != fat_write_single_block(sector, odd_buf)) {
+        //printf("Fail Write DirEntry\n"); // TODO: Remove
+      }
+      f->size = new_size;
+    }
+  }
+
+  f->pos += bytes_written;
+  return bytes_written; // errno is already set
+}
+
+/*! Read bytes from a file.
+    Returns the number of bytes read, or -1 in case of failure.
+
+    Sets errno == EPERM if the module is not initialized.
+    Sets errno == EINVAL if the file descriptor is out of the valid range.
+    Sets errno == EBADF if the file descriptor does not match an open file.
+    Sets errno == EAGAIN if a bad cluster is encountered during the read.
+*/
+int fat_read(int fd, uint8_t *buf, uint32_t sz) {
+  errno = 0;
+
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  if (fd < FAT_FD_OFFSET || fd >= FAT_FD_OFFSET + FAT_MAX_FILES) {
+    errno = EINVAL;
+    return FAT_FAIL;
+  }
+
+  FatFile *f = &fat_open_files[fd - FAT_FD_OFFSET];
+  if (f->free) {
+    errno = EBADF;
+    return FAT_FAIL;
+  }
+
+  if (f->pos + sz > f->size) {
+    // Reading beyond current end of file.
+    sz = f->size - f->pos;
+  }
+
+  // TODO: Acquire all needed clusters before writing.
+  // This is to minimize the amount of disk_read().
+
+  // TODO: Read block size from somewhere
+  uint32_t secsz = fat_pinfo.bytes_per_sector;
+  uint32_t bytes_read = 0;
+  uint8_t odd_buf[secsz];
+  uint8_t *rdbuf; // Where the next read is to
+  uint32_t tv; // Value read from FAT
+
+  uint32_t secoff = (f->pos / secsz) % fat_pinfo.sectors_per_cluster;
+  uint32_t secfirst = fat_first_sector_of_cluster(f->current_cluster);
+  uint32_t sector = secfirst + secoff;
+
+  uint32_t byteoff = f->pos % secsz; // Offset from start of sector
+  uint32_t rdsz = 0; // Amount of bytes to read next iteration
+
+  errno = 0; // Set in loop if something goes wrong
+
+  while (sz > 0) {
+    rdsz = umin(secsz - byteoff, sz); // Start by writing up to next sector
+    sector = secfirst + secoff;
+
+    // If not a whole sector, we must read into the odd buffer
+    if (rdsz < secsz) {
+      rdbuf = odd_buf; // Read into the odd buffer
+    }
+    else {
+      rdbuf = buf + bytes_read;
+    }
+
+    // Read block
+    if (FAT_SUCCESS != fat_read_single_block(sector, rdbuf)) {
+      //printf("Failed Read\n"); // TODO: Remove
+      break;
+    }
+
+    // If not a whole sector, we must copy over the data now
+    if (rdsz < secsz) {
+      memcpy(buf + bytes_read, rdbuf + byteoff, rdsz);
+    }
+
+    // Update counters
+    bytes_read += rdsz;
+    sz -= rdsz;
+    if (sz > 0 && byteoff + rdsz >= secsz) { // Update sector if end is reached
+      secoff++;
+      if (secoff >= fat_pinfo.sectors_per_cluster) {
+        if (FAT_SUCCESS != fat_get_table_value(f->current_cluster, &tv)) {
+          // Out of disk space
+          errno = ENOSPC;
+          break;
+        }
+        else if (FAT_TV_BAD(tv)) {
+          //printf("Error: Reading bad cluster\n");
+          errno = EBADF;
+          break;
+        }
+        else if (FAT_TV_LAST(tv)) {
+          //printf("Error: Reading last cluster\n");
+          errno = EBADF; // This should not be reached since sz was adjusted
+          break;
+        }
+        else if (FAT_TV_FREE(tv)) {
+          //printf("Error: Reading free cluster\n");
+          errno = EBADF;
+          break;
+        }
+        // All of the above errors point to the FAT being corrupted
+        f->current_cluster = tv;
+
+        secoff = 0;
+        secfirst = fat_first_sector_of_cluster(f->current_cluster);
+      }
+    }
+
+    // No byte offset next read (can only happen in first iteration)
+    byteoff = 0; // Must happen here as it used in counter update
+  }
+
+  f->pos += bytes_read;
+  return bytes_read; // errno is already set
+}
+
+/*! Set the cursor in the open file.
+    Returns the absolute offset of the cursor in the file, or -1 in case of failure.
+    The parameter whence determines how the pos is interpreted.
+
+    If whence == SEEK_SET then it is in absolute position, in bytes.
+    If whence == SEEK_CUR then it is relative to the current position, in bytes.
+    If whence == SEEK_END then it is relative to the end of the file, in bytes.
+
+    Sets errno == EPERM if the module is not initialized.
+    Sets errno == EINVAL if the file descriptor is out of the valid range.
+    Sets errno == EBADF if the file descriptor does not match an open file.
+    Sets errno == EAGAIN if a bad cluster is encountered during the search.
+    Sets errno == EPIPE if the seek position is outside the range of the file.
+*/
+off_t fat_lseek(int fd, off_t pos, int whence) {
+  errno = 0;
+
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  if (fd < FAT_FD_OFFSET || fd >= FAT_FD_OFFSET + FAT_MAX_FILES) {
+    errno = EINVAL;
+    return FAT_FAIL;
+  }
+
+  FatFile *f = &fat_open_files[fd - FAT_FD_OFFSET];
+  if (f->free) {
+    errno = EBADF;
+    return FAT_FAIL;
+  }
+
+  long abs_pos = pos;
+  if (whence == SEEK_SET) {
+    abs_pos = pos;
+  }
+  else if (whence == SEEK_CUR) {
+    abs_pos = f->pos + pos;
+  }
+  else if (whence == SEEK_END) {
+    abs_pos = f->size + pos;
+  }
+  else {
+    errno = EINVAL;
+    return FAT_FAIL;
+  }
+
+  // We allow seeking to the character just behind the last
+  if (abs_pos < 0 || abs_pos > f->size) {
+    errno = EPIPE;
+    return FAT_FAIL;
+  }
+
+  uint32_t bytes_per_cluster = fat_pinfo.bytes_per_sector * fat_pinfo.sectors_per_cluster;
+
+  uint32_t clusters_to_search = 0; // The number of clusters we must search through
+  uint32_t bytes_to_search = 0; // The number of bytes we must search through
+  uint32_t s_cluster = 0; // The current cluster in the search
+
+  if (abs_pos > f->pos) { // Seeking forward
+    bytes_to_search = abs_pos - f->pos;
+    clusters_to_search = ((f->pos % bytes_per_cluster) + bytes_to_search) / bytes_per_cluster;
+    s_cluster = f->current_cluster;
+  }
+  else { // Seeking backwards
+    bytes_to_search = abs_pos;
+    clusters_to_search = bytes_to_search / bytes_per_cluster;
+    s_cluster = f->start_cluster;
+  }
+
+  uint32_t tv = 0; // Table value read from FAT
+  uint32_t i;
+  for (i = 0; i < clusters_to_search; i++) {
+    if (FAT_SUCCESS != fat_get_table_value(s_cluster, &tv)) {
+      break;
+    }
+    else if (FAT_TV_BAD(tv)) {
+      errno = EAGAIN;
+      break;
+    }
+    else if (FAT_TV_LAST(tv)) {
+      // This should never happen due to range check
+      //printf("Error: EOF in lseek\n");
+      return FAT_FAIL;
+    }
+    else {
+      s_cluster = tv;
+    }
+  }
+
+  f->current_cluster = s_cluster;
+  f->pos = abs_pos;
+
+  errno = 0;
+  return f->pos;
+}
+
+/*! Deletes a file.
+  Returns 0 if successful, or -1 in case of failure.
+
+  Sets errno == EPERM  if the module is not initialized.
+  Sets errno == ENOENT if the path is not a valid file.
+  Sets errno == BUSY   if the file is open.
+  Sets errno == EIO    if there occured read / write errors.
+  Sets errno == BADF   if the FAT is corrupted.
+*/
+int fat_unlink(const char *path) {
+  errno = 0;
+
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  // 1. Resolve path to final directory entry
+  uint8_t buf[fat_pinfo.bytes_per_sector];
+  FatDirEntryIdx di;
+  if (0 != fat_resolve_path(path, buf, &di)) {
+    return FAT_FAIL; // Keep errno from path resolution
+  }
+
+  // 2. Check if the file is open anywhere
+  FatFile *f = 0; // For brevity
+  int i = 0;
+  for (i = 0; i < FAT_MAX_FILES; i++) {
+    f = &fat_open_files[i];
+    if (!f->free && f->dir_idx.cluster == di.cluster &&
+        f->dir_idx.sector == di.sector &&
+        f->dir_idx.index == di.index) {
+
+      errno = EBUSY;
+      return FAT_FAIL;
+    }
+  }
+
+  if (FAT_SUCCESS != fat_delete(path, buf)) {
+    return -1;
+  }
+
+  return 0;
+}
+
+/*! Creates a new file or overwrite an existing one.
+  Returns file descriptor if successful, or -1 in case of failure.
+
+  Corresponds to fat_open with oflag equal to O_CREAT | O_WRONLY | O_TRUNC.
+ */
+int fat_creat(const char *path) {
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  return fat_open(path, O_CREAT | O_WRONLY | O_TRUNC);
+}
+
+/*! Creates a new directory.
+  Returns 0 on success, -1 on failure.
+*/
+int fat_mkdir(const char *path) {
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  uint8_t sector[fat_pinfo.bytes_per_sector];
+  FatDirEntryIdx dir_idx;
+
+  errno = 0;
+
+  // Check if directory already exists
+  if (FAT_SUCCESS == fat_resolve_path(path, sector, &dir_idx)) {
+    errno = EEXIST;
+  }
+  else {
+    int fd = 0; // Should be ignored
+    if (FAT_SUCCESS == fat_create(path, &dir_idx, sector, &fd, 0)) {
+      assert(fd == 0);
+
+      // Empty folder
+      uint32_t sec_addr = fat_first_sector_of_cluster(dir_idx.cluster);
+      if (FAT_SUCCESS == fat_read_single_block(sec_addr, sector)) {
+        sector[0] = FAT_DIR_ENTRY_LAST; // Effectively empty the cluster
+        fat_write_single_block(sec_addr, sector); // Sets errno
+      }
+      else {
+        errno = EIO;
+      }
+    }
+    else {
+      // Keep errno
+      return FAT_FAIL;
+    }
+  }
+
+  return errno == 0 ? FAT_SUCCESS : FAT_FAIL;
+}
+
+/*! Removes an empty directory.
+  Returns 0 on success, -1 on failure.
+*/
+int fat_rmdir(const char *path) {
+  if (!fat_initialized) {
+    errno = EPERM;
+    return FAT_FAIL;
+  }
+
+  // We read folder contents into this buffer
+  // This saves a disk read at the cost of memory
+  uint8_t chksector[fat_pinfo.bytes_per_sector];
+  uint8_t sector[fat_pinfo.bytes_per_sector];
+  FatDirEntryIdx dir_idx;
+
+  errno = 0;
+
+  // Find directory already exists
+  if (FAT_SUCCESS != fat_resolve_path(path, sector, &dir_idx)) {
+    errno = ENOENT;
+  }
+  else {
+    // Ensure it is a directory
+    uint8_t attrib = fat_attrib_of_dir_entry(sector, dir_idx.index);
+    if (!(attrib & FAT_DIRECTORY)) {
+      errno = ENOTDIR;
+    }
+    else {
+      // Ensure it is empty
+      uint8_t entstat = FAT_DIR_ENTRY_FREE;
+      uint32_t cluster = fat_cluster_of_dir_entry(sector, dir_idx.index);
+      uint32_t sec_start = fat_first_sector_of_cluster(cluster);
+      uint32_t sec = 0;
+      uint32_t ent = 0;
+
+      fat_read_single_block(sec_start, chksector);
+      do {
+        entstat = fat_get_uint8(chksector + ent * FAT_DIR_ENTRY_WIDTH);
+
+        // Increase indicies
+        if (++ent >= fat_pinfo.entries_per_sector) {
+          ent = 0;
+          if (++sec >= fat_pinfo.sectors_per_cluster) {
+            sec = 0;
+            if (FAT_SUCCESS != fat_acquire_next_cluster(&cluster, 0)) {
+              break;
+            }
+            sec_start = fat_first_sector_of_cluster(cluster);
+          }
+          if (FAT_SUCCESS != fat_read_single_block(sec_start + sec, chksector)) {
+            break;
+          }
+          sec = 0;
+        }
+      } while (errno == 0 && entstat == FAT_DIR_ENTRY_FREE);
+
+      if (errno == 0 && entstat != FAT_DIR_ENTRY_LAST) {
+        errno = ENOTEMPTY;
+      }
+      else if (errno == 0) {
+        // Delete the folder
+        fat_delete(path, sector); // Keep errno in case of failure
+      }
+      // Keep errno from if IO error
+    }
+  }
+
+  return errno == 0 ? FAT_SUCCESS : FAT_FAIL;
+}

--- a/c/libsd/fat32.h
+++ b/c/libsd/fat32.h
@@ -1,0 +1,107 @@
+/*
+   Copyright 2017 Max Rishoej Pedersen
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * Library for accessing files on FAT32 formatted disk.
+ *
+ * Authors: Max Rishoej (maxrishoej@gmail.com)
+ */
+
+#ifndef FAT32_H_
+#define FAT32_H_
+
+#include <stdint.h>
+#include <sys/types.h>
+
+typedef struct {
+  // Partition
+  uint32_t vol_begin_addr;
+
+  // General FAT
+  uint32_t bytes_per_sector;
+  uint32_t sectors_per_cluster;
+  uint32_t num_res_sectors;
+  uint32_t num_fats;
+  uint32_t num_dir_entries;
+  uint32_t num_total_sectors;
+  uint32_t media_desc_type;
+  uint32_t sectors_per_fat;
+
+  // FAT32 only
+  uint32_t root_dir_cluster;
+
+  // Derived
+  uint32_t fat_begin_addr;
+  uint32_t cluster_begin_addr;
+  uint32_t entries_per_sector;
+
+  // Calculate address of root dir
+  uint32_t root_dir_addr;
+} FatPartitionInfo;
+
+// Index of a directory entry
+typedef struct {
+  uint32_t cluster;
+  uint32_t sector;
+  uint32_t index;
+} FatDirEntryIdx;
+
+// File on a FAT32 volume
+typedef struct {
+  uint8_t free; // Is the file free?
+  uint32_t pos; // Seek position in file
+  FatDirEntryIdx dir_idx; // Index of the file
+  uint32_t start_cluster; // First cluster of file. Stored for speed.
+  uint32_t current_cluster; // Current cluster that pos is in
+  uint32_t size; // Size of file. Could be read from dir_idx
+} FatFile;
+
+int fat_load_partition_info(uint8_t idx, FatPartitionInfo *pinfo);
+int fat_load_first_partition_info(FatPartitionInfo *pinfo);
+
+int fat_init(const FatPartitionInfo *pinfo);
+
+int fat_open(const char *path, int oflag);
+int fat_close(int fd);
+
+int fat_write(int fd, uint8_t *buf, uint32_t sz);
+int fat_read(int fd, uint8_t *buf, uint32_t sz);
+
+off_t fat_lseek(int fd, off_t pos, int whence);
+
+int fat_unlink(const char *path);
+
+int fat_mkdir(const char *path);
+int fat_rmdir(const char *path);
+
+#endif

--- a/c/libsd/sd_spi.c
+++ b/c/libsd/sd_spi.c
@@ -1,0 +1,393 @@
+/*
+   Copyright 2017 Max Rishoej Pedersen
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * Driver for SD host controller using the SPI protocol.
+ *
+ * Authors: Max Rishoej (maxrishoej@gmail.com)
+ */
+
+#include <stdio.h> // Just for debugging
+#include <stdint.h>
+#include <machine/spm.h>
+#include <machine/rtc.h>
+
+#include "sd_spi.h"
+
+// Pointers to host controller registers
+volatile _SPM int *sd_ptr        = (volatile _SPM int *) 0xF00b0000;
+volatile _SPM int *sd_cs_ptr     = (volatile _SPM int *) 0xF00b0004;
+volatile _SPM int *sd_en_ptr     = (volatile _SPM int *) 0xF00b0008;
+volatile _SPM int *sd_clkdiv_ptr = (volatile _SPM int *) 0xF00b000c;
+
+// Timeout limits when waiting for card
+// No reason not to have them fairly large
+#define ACMD41_MAX_TRIES  (1000)
+#define SD_WRITE_MAX_WAIT (1000000)
+#define SD_READ_MAX_WAIT  (1000000)
+#define SD_BUSY_MAX_WAIT  (1000000)
+
+#define SD_DATA_BEGIN_TOKEN (0xFE)
+
+// Global SD info
+SDInfo sd_global_info;
+SDResponse sd_res; // Last response from card
+
+// TODO: Bound loops
+uint8_t spi_send(const uint8_t dat) {
+  while(*sd_en_ptr != 0);
+  *sd_ptr = (int)dat;
+  while(*sd_en_ptr != 0);
+  return *sd_ptr;
+}
+
+// Sets the clock rate of the controller
+SDErr spi_set_clockrate(const uint32_t rate) {
+  uint32_t patmos_rate = get_cpu_freq();
+
+  if (patmos_rate % rate != 0) {
+    /*
+    printf("Invalid clock rate (%ld)! Must be divisor of CPU rate (%ld)\n",
+           rate, patmos_rate);
+    */
+    return SD_CLK_DIVISOR;
+  }
+  if (rate > patmos_rate / 2) {
+    /*
+    printf("Invalid clock rate (%ld)! Must be smaller than or equal to"
+           "half the CPU rate (%ld)\n", rate, patmos_rate);
+    */
+    return SD_CLK_HIGH;
+  }
+
+  uint32_t clkdiv = (patmos_rate / rate) / 2;
+  while(*sd_en_ptr != 0);
+  *sd_clkdiv_ptr = clkdiv;
+
+  return SD_SUCCESS;
+}
+
+// Clears SPI buffers
+void spi_clear() {
+  *sd_cs_ptr = 1;
+  spi_send(0xFF);
+  *sd_cs_ptr = 0;
+}
+
+// Sends a SD command, returning the 1-byte response (R1)
+uint8_t sd_cmd(uint8_t cmd, uint8_t arg0, uint8_t arg1,
+               uint8_t arg2, uint8_t arg3, uint8_t crc)
+{
+  spi_clear(); // Ensure SPI buffers of SD card are cleared
+
+  spi_send(cmd | 0b01000000); // Commands always begin with 01
+  spi_send(arg0);
+  spi_send(arg1);
+  spi_send(arg2);
+  spi_send(arg3);
+  spi_send(crc | 0b00000001); // Commands always end with 1
+
+  // Wait for response
+  uint8_t response; // R1 response
+  int n;
+  for (n = 0; n < 10; n++) {
+    response = spi_send(0xFF);
+    if (response != 0xFF)
+      break;
+  }
+  return response; // 0xFF if no response received
+}
+
+// Sends ACMD41 / SD_SEND_OP_COND
+// hcs =  0 -> Initialize without HCS
+// hcs != 0 -> Initialize with HCS
+SDErr sd_send_op_cond_cmd(uint8_t hcs) {
+  int i = 0;
+
+  hcs = hcs == 0 ? 0x00 : 0x40; // Adjust parameter
+
+  for (i = 0; i < ACMD41_MAX_TRIES; i++) {
+    sd_res.r1 = sd_cmd(55, 0, 0, 0, 0, 0xFF); // APP_CMD
+    sd_res.r1 = sd_cmd(41, hcs, 0, 0, 0, 0xFF); // ACMD41 (SD_SEND_OP_COND)
+
+    if (sd_res.r1 == 0) { // Success. Card initialized.
+      /*
+      printf("ACMD41 successful after %d tries %s HCS\n", i,
+             hcs ? "with" : "without");
+      */
+      return SD_SUCCESS;
+    }
+    else if (sd_res.r1 != 0x01) { // Bad response.
+      /*
+      printf("Error: %02X (%d)\n", res, i);
+      sd_print_r1(res);
+      */
+      return SD_SENDOPCOND_BADRES;
+    }
+  }
+
+  return SD_SENDOPCOND_UNABLE;
+}
+
+// (DEBUG) Prints a block of data in hex
+void sd_print_block(uint8_t *block, uint32_t block_sz) {
+  int w = 16; // Uint8_Ts per rows
+  int h = block_sz / w;
+
+  int i, j;
+  for (i = 0; i < h; i++) {
+    printf("%03d: ", i*w);
+    for (j = 0; j < w; j++) {
+      printf("%02X ", block[i*w + j]);
+    }
+    printf("\n");
+  }
+}
+
+// (DEBUG) Prints a quickly understandable format of a R1 response
+void sd_print_r1(uint8_t r) {
+  if ((r & 0x80) != 0) printf("Invalid ");
+  if ((r & 0x40) != 0) printf("Param ");
+  if ((r & 0x20) != 0) printf("Addr ");
+  if ((r & 0x10) != 0) printf("EraseSeq ");
+  if ((r & 0x08) != 0) printf("Crc ");
+  if ((r & 0x04) != 0) printf("Cmd ");
+  if ((r & 0x02) != 0) printf("EraseReset ");
+  if ((r & 0x01) != 0) printf("Idle");
+  printf("\n");
+}
+
+// Reads a block of data from the card using CMD17 (READ_SINGLE_BLOCK)
+SDErr sd_read_single_block(uint32_t addr, uint8_t *buffer, uint32_t block_sz) {
+  int i;
+
+  // Send CMD17 (READ_SINGLE_BLOCK)
+  // Assumes CRC disabled
+  sd_res.r1 = sd_cmd(17, addr >> 24, addr >> 16, addr >> 8, addr, 0xFF);
+  if (sd_res.r1 != 0) {
+    return SD_BADRES;
+  }
+
+  // Wait for data begin token
+  for (i = 0; i < SD_READ_MAX_WAIT; i++) {
+    sd_res.r1 = spi_send(0xFF);
+    if (sd_res.r1 == SD_DATA_BEGIN_TOKEN)
+      break;
+  }
+  if (i == SD_READ_MAX_WAIT) {
+    return SD_TIMEOUT;
+  }
+
+  // Read data block
+  for (i = 0; i < block_sz; i++) {
+    buffer[i] = spi_send(0xFF); // Exchange byte
+  }
+
+  // Read CRC16
+  spi_send(0xFF);
+  spi_send(0xFF);
+
+  return SD_SUCCESS;
+}
+
+// Writes a block of data to the card using CMD24 (WRITE_BLOCK)
+SDErr sd_write_single_block(uint32_t addr, uint8_t *buffer, uint32_t block_sz) {
+  int i;
+
+  // Send CMD24 (WRITE_BLOCK)
+  // Assumes CRC disabled
+  sd_res.r1 = sd_cmd(24, addr >> 24, addr >> 16, addr >> 8, addr, 0xFF);
+  if (sd_res.r1 != 0) {
+    return SD_BADRES;
+  }
+
+  // Send a Start Block Token
+  sd_res.r1 = spi_send(SD_DATA_BEGIN_TOKEN);
+
+  // Send data block
+  for (i = 0; i < block_sz; i++) {
+    spi_send(buffer[i]);
+  }
+
+  // Wait for data response token
+  for (i = 0; i < SD_WRITE_MAX_WAIT; i++) {
+    sd_res.r1 = spi_send(0xFF);
+    if (sd_res.r1 != 0xFF) // Wait for a response token
+      break;
+  }
+  if (i == SD_WRITE_MAX_WAIT) {
+    //printf("Timed out waiting for response!\n");
+    return SD_TIMEOUT;
+  }
+
+  // Parse data response token
+  switch (sd_res.r1 & 0x1F) {
+  case 0b00101: // Data accepted
+    break;
+  case 0b01011: // Data rejected due to CRC
+    return SD_BADCRC;
+  case 0b01101: // Data rejected due to Write Error
+    return SD_WR;
+  default:
+    //printf("Bad data response: %02X\n", res);
+    return SD_BADRES;
+  }
+
+  // Read busy
+  for (i = 0; i < SD_BUSY_MAX_WAIT; i++) {
+    sd_res.r1 = spi_send(0xFF);
+    if (sd_res.r1 != 0x00) // Busy holds the data line low
+      break;
+  }
+  if (i == SD_BUSY_MAX_WAIT) {
+    //printf("Timed out waiting for non-busy!\n");
+    return SD_TIMEOUT;
+  }
+
+  return SD_SUCCESS;
+}
+
+SDErr sd_init() {
+  int i;
+
+  // Set clock rate to 400kHz
+  SDErr errsv = spi_set_clockrate(400000); // Save so available for printing
+  if (errsv != SD_SUCCESS) {
+    return errsv;
+  }
+
+  // Set CS high for wake-up phase
+  *sd_cs_ptr = 1;
+
+  // Send 80 dummy bits == 10 dummy bytes
+  for (i = 0; i < 10; i++) {
+    spi_send(0xFF);
+  }
+
+  // Set CS low to begin sending commands
+  *sd_cs_ptr = 0;
+
+  // Send GO_IDLE
+  //printf("Initializing card\n");
+  sd_res.r1 = sd_cmd(0, 0, 0, 0, 0, 0x94); // GO_IDLE
+  if (sd_res.r1 != 1) {
+    //printf("Error: %02X\n", sd_res.r1);
+    return SD_GOIDLE;
+  }
+
+  //printf("Card entered SPI Mode\n");
+
+  // Send CMD8 (SEND_IF_COND)
+  const uint8_t volt_range = 0x01; // 0x01 = 2.7V - 3.6V
+  const uint8_t check_pattern = 0xAA; // Constant
+  //printf("Sending CMD8\n");
+  sd_res.r7[0] = sd_cmd(8, 0, 0, volt_range, check_pattern, 0x86);
+  //printf("Initial: ");
+  //sd_print_r1(sd_res.r7[0]);
+  for (i = 0; i < 4; i++) {
+    sd_res.r7[1 + i] = spi_send(0xFF);
+    //printf("%02X ", sd_res.r7[1 + i]);
+  }
+  //printf("\n");
+
+  // Verify response
+  if (sd_res.r7[0] != 0x01 ||
+      sd_res.r7[1] != 0x00 || sd_res.r7[2] != 0x00 ||
+      sd_res.r7[3] != volt_range || sd_res.r7[4] != check_pattern) {
+
+    /*
+    printf("Invalid R7 response to CMD8: ");
+    for (i = 0; i < 5; i++) {
+      printf("%02X ", sd_res.r7[i]);
+    }
+    printf("\n");
+    */
+
+    return SD_SENDIFCOND_BADRES;
+  }
+
+  // Send ACMD41  (SD_SEND_OP_COND)
+  //printf("Sending ACMD41\n");
+
+  // First try with HCS
+  if (SD_SUCCESS != sd_send_op_cond_cmd(1)) {
+    errsv = sd_send_op_cond_cmd(0); // On failure, try without
+    if (SD_SUCCESS != errsv) {
+      //printf("Unable to initialize card\n");
+      return errsv;
+    }
+  }
+
+  //printf("Card initialized to Data Transfer Mode\n");
+
+  // Disable CRC - CMD59
+  /*
+  printf("Disabling CRC\n");
+  sd_res.r1 = sd_cmd(59, 0, 0, 0, 0, 0xFF);
+  if (sd_res.r1 != 0) {
+    printf("Unable to disable CRC: ");
+    sd_print_r1(sd_res.r1);
+    printf("\n");
+    return SD_CRC_BADRES;
+  }
+  */
+
+  // TODO: Read OCR of card (CMD58)
+
+  // Set block length - CMD16
+  //printf("Setting block length to 512 bytes\n");
+  sd_res.r1 = sd_cmd(16, 0, 0, 0x02, 0, 0xFF); // Block Length = 512 bytes = 0x0200
+  if (sd_res.r1 != 0) {
+    /*
+    printf("Unable to set block length: ");
+    sd_print_r1(res);
+    printf("\n");
+    */
+    return SD_BLKLEN_BADRES;
+  }
+  sd_global_info.block_sz = 512;
+
+  // Increase clock rate to maximum
+  errsv = spi_set_clockrate(20000000); // 20MHz
+  if (errsv != SD_SUCCESS) {
+    //printf("Unable to increase clock rate");
+    return errsv;
+  }
+
+  return SD_SUCCESS;
+}
+
+SDErr sd_info(SDInfo *sdinfo) {
+  *sdinfo = sd_global_info;
+  return SD_SUCCESS;
+}

--- a/c/libsd/sd_spi.h
+++ b/c/libsd/sd_spi.h
@@ -1,0 +1,90 @@
+/*
+   Copyright 2017 Max Rishoej Pedersen
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * Driver for SD host controller using the SPI protocol.
+ *
+ * Authors: Max Rishoej (maxrishoej@gmail.com)
+ */
+
+#ifndef SD_SPI_DRIVER_H_
+#define SD_SPI_DRIVER_H_
+
+#include <stdint.h>
+
+// Error codes
+typedef enum {
+  SD_SUCCESS,
+  SD_BADRES,
+  SD_CLK_DIVISOR, // Clock rate not an even divisor
+  SD_CLK_HIGH,    // Clock rate too high
+  SD_GOIDLE,      // Could not GO_IDLE
+  SD_TIMEOUT,
+  SD_SENDIFCOND_BADRES,
+  SD_SENDOPCOND_BADRES,
+  SD_SENDOPCOND_UNABLE,
+  SD_CRC_BADRES,
+  SD_BLKLEN_BADRES,
+  SD_BADCRC,
+  SD_WR,
+} SDErr;
+
+// Last response from SD Card
+// TODO: Fill in missing types
+typedef union {
+  uint8_t r1;
+  uint8_t r7[5];
+} SDResponse;
+
+// --- SPI related ---
+SDErr spi_set_clockrate(const uint32_t rate);
+uint8_t spi_send(const uint8_t dat);
+void spi_clear();
+
+// --- SD related ---
+typedef struct {
+  uint32_t block_sz;
+} SDInfo;
+
+SDErr sd_init();
+SDErr sd_read_single_block(uint32_t addr, uint8_t *buffer, uint32_t block_sz);
+SDErr sd_write_single_block(uint32_t addr, uint8_t *buffer, uint32_t block_sz);
+SDErr sd_info();
+
+uint8_t sd_cmd(uint8_t cmd, uint8_t arg0, uint8_t arg1,
+               uint8_t arg2, uint8_t arg3, uint8_t crc);
+
+// Debug methods
+void sd_print_block(uint8_t *block, uint32_t block_sz);
+void sd_print_r1(uint8_t r);
+
+#endif

--- a/c/libsd/sddisk.c
+++ b/c/libsd/sddisk.c
@@ -1,0 +1,112 @@
+/*
+   Copyright 2017 Max Rishoej Pedersen
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * Generic disk interface for use with file system module.
+ * Uses SD card as disk.
+ *
+ * Authors: Max Rishoej (maxrishoej@gmail.com)
+ */
+
+#include "sddisk.h"
+#include "sd_spi.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+// Global disk info
+DiskInfo disk_global_info = { .initialized = 0 };
+
+// Initializes disk
+// Returns 0 on success, -1 on failure
+int disk_init() {
+  // NOTE: In case of failure inspect res which is an SDErr (sd_spi.h)
+  int res = sd_init();
+  if (SD_SUCCESS != res) {
+    errno = EIO;
+    return -1;
+  }
+
+  SDInfo sdinfo;
+  sd_info(&sdinfo);
+  disk_global_info.initialized = 1;
+  disk_global_info.block_sz = sdinfo.block_sz;
+
+  errno = 0;
+  return 0;
+}
+
+// Copies over disk info
+int disk_info(DiskInfo *dinfo) {
+  *dinfo = disk_global_info;
+  return disk_global_info.initialized ? 0 : 1;
+}
+
+// Read a number of blocks from the disk
+// Returns 0 on success, -1 on failure
+int disk_read(uint32_t block, uint8_t *buf, uint32_t num_blocks) {
+  const uint32_t blksz = disk_global_info.block_sz;
+  uint32_t i;
+
+  // Read all whole sectors
+  for (i = 0; i < num_blocks; i++) {
+    if (SD_SUCCESS != sd_read_single_block(block + i, buf + i * blksz, blksz)) {
+      errno = EIO;
+      return -1;
+    }
+  }
+
+  errno = 0;
+  return 0;
+}
+
+// Write a number of blocks to the disk
+// Returns 0 on success, -1 on failure
+int disk_write(uint32_t block, uint8_t *buf, uint32_t num_blocks) {
+  SDErr res = SD_SUCCESS;
+  const uint32_t blksz = disk_global_info.block_sz;
+  uint32_t i;
+
+  // Write all whole sectors
+  for (i = 0; i < num_blocks; i++) {
+    res = sd_write_single_block(block + i, buf + i * blksz, blksz);
+    if (SD_SUCCESS != res) {
+      errno = EIO;
+      return -1;
+    }
+  }
+
+  errno = 0;
+  return 0;
+}

--- a/c/libsd/sddisk.h
+++ b/c/libsd/sddisk.h
@@ -1,0 +1,57 @@
+/*
+   Copyright 2017 Max Rishoej Pedersen
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * Generic disk interface for use with file system module.
+ * Uses SD card as disk.
+ *
+ * Authors: Max Rishoej (maxrishoej@gmail.com)
+ */
+
+#ifndef SD_INTERFACE_H_
+#define SD_INTERFACE_H_
+
+#include <stdint.h>
+
+typedef struct {
+  uint8_t initialized;
+  uint32_t block_sz;
+} DiskInfo;
+
+int disk_init();
+int disk_info(DiskInfo *dinfo);
+
+int disk_read(uint32_t block, uint8_t *buf, uint32_t num_blocks);
+int disk_write(uint32_t block, uint8_t *buf, uint32_t num_blocks);
+
+#endif

--- a/c/sdtest.c
+++ b/c/sdtest.c
@@ -1,0 +1,987 @@
+/*
+   Copyright 2017 Max Rishoej Pedersen
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * File for testing FAT32 on SD card.
+ *
+ * Authors: Max Rishoej (maxrishoej@gmail.com)
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <machine/spm.h>
+
+// NOTE: Source files are imported here, not headers.
+// This is to access functions otherwise hidden.
+#include "libsd/sddisk.c"
+#include "libsd/fat32.c"
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+// Reused fields
+uint8_t res; // Response from SD card
+uint8_t buffer[512];
+FatPartitionInfo pinfo;
+int i;
+
+// --- Utility functions ---
+
+// Prints a directory entry on a single line
+void print_dir_entry(uint8_t *buffer, FatDirEntryIdx *dir_idx) {
+  int entry_idx = FAT_DIR_ENTRY_WIDTH * dir_idx->index;
+
+  // Check if it's an empty entry
+  if (buffer[entry_idx] == 0xE5 || buffer[entry_idx] == 0x00) {
+    return;
+  }
+
+  int i;
+
+  uint8_t long_name[512];
+  uint8_t short_name[12]; // 11 bytes + null terminating
+  uint8_t attrib;
+  uint32_t first_cluster;
+  uint32_t file_size;
+
+  // First get long name, if it exists
+  long_name[0] = 0; // Terminate in case of no long name found
+  fat_get_long_name_uint8(buffer, dir_idx, long_name);
+
+  // Indicies might have been updated
+  entry_idx = FAT_DIR_ENTRY_WIDTH * dir_idx->index;
+
+  fat_get_string(buffer + entry_idx, short_name, 11);
+  short_name[11] = 0; // Terminate
+
+  attrib = fat_attrib_of_dir_entry(buffer, dir_idx->index);
+  first_cluster = fat_cluster_of_dir_entry(buffer, dir_idx->index);
+
+  file_size = fat_get_uint32(buffer + entry_idx + 0x1C);
+
+  printf("%02ld:", dir_idx->index);
+  printf(" %s", short_name);
+  printf(" (> %ld)", first_cluster);
+  printf("\t[Sz = %ld]", file_size);
+  printf("\t%s", long_name);
+  printf("\n");
+}
+
+// --- Test functions ---
+// The prefix "ptest" indicates that the functions always succeed, but just print.
+// The prefix "test" indicates that it is an actual test.
+
+// Write data to card and read it back again
+// NOTE: Requires reformat of card
+int ptest_sd_read_write() {
+
+  // Read block
+  res = sd_read_single_block(0, buffer, 512);
+  printf("RD Res: %d\n", res);
+  sd_print_block(buffer, 512);
+
+  // Alter and write back
+  memcpy(buffer, buffer, 512);
+  buffer[16] = 0;
+  buffer[32] = 0;
+  buffer[48] = 0;
+  res = sd_write_single_block(0, buffer, 512);
+  printf("WR Res: %d\n", res);
+
+  // Read again
+  res = sd_read_single_block(0, buffer, 512);
+  printf("RD Res: %d\n", res);
+  sd_print_block(buffer, 512);
+
+  return 0;
+}
+
+// Load partition info and print it
+int ptest_pinfo() {
+  fat_load_first_partition_info(&pinfo);
+
+  printf("\nPartition Info:\n");
+  printf("VolBeginAddr: %ld\n", pinfo.vol_begin_addr);
+  printf("BytesPerSector: %ld\n", pinfo.bytes_per_sector);
+  printf("SectorsPerCluster: %ld\n", pinfo.sectors_per_cluster);
+  printf("NumResSectors: %ld\n", pinfo.num_res_sectors);
+  printf("NumFATs: %ld\n", pinfo.num_fats);
+  printf("NumDirEntries: %ld\n", pinfo.num_dir_entries);
+  printf("NumTotalSectors: %ld\n", pinfo.num_total_sectors);
+  printf("SectorsPerFAT: %ld\n", pinfo.sectors_per_fat);
+  printf("\n");
+
+  return 0;
+}
+
+// Test disk reads
+// NOTE: Requires reformat of card
+int ptest_root_dir_raw() {
+  uint8_t buffer[512];
+  uint32_t addr = pinfo.root_dir_addr + 1;
+
+  disk_read(addr, buffer, 0);
+  sd_print_block(buffer, 512);
+
+  disk_read(addr, buffer, 1);
+  sd_print_block(buffer, 512);
+
+  disk_read(addr, buffer, 2);
+  sd_print_block(buffer, 512);
+
+  return 0;
+}
+
+// Test FAT lseek and read
+int ptest_fat_lseek_read(char *path) {
+  int fd = -1;
+  uint8_t test_buf3[10 + 1];
+
+  test_buf3[10] = 0;
+  fd = fat_open(path, O_RDWR);
+
+  fat_lseek(fd, 5, SEEK_CUR);
+  fat_read(fd, test_buf3, 10);
+  printf("%s\n", test_buf3);
+
+  fat_lseek(fd, -10, SEEK_CUR);
+  fat_read(fd, test_buf3, 10);
+  printf("%s\n", test_buf3);
+
+  return 0;
+}
+
+// Print directory contents
+int ptest_print_dir(uint32_t start_cluster) {
+  FatDirEntryIdx dir_idx;
+  dir_idx.cluster = start_cluster;
+  dir_idx.sector = 0;
+  dir_idx.index = 0;
+  uint32_t start_sector = 0;
+
+  uint32_t entries_per_sector = pinfo.bytes_per_sector / FAT_DIR_ENTRY_WIDTH;
+  int done = 0;
+
+  while (!done) {
+    // Read sector
+    start_sector = fat_first_sector_of_cluster(dir_idx.cluster);
+    disk_read(start_sector + dir_idx.sector, buffer, 1);
+
+    for (dir_idx.index = 0; dir_idx.index < entries_per_sector; dir_idx.index++) {
+      print_dir_entry(buffer, &dir_idx);
+
+      // Check first byte to see if last entry
+      if (0x00 == buffer[dir_idx.index * FAT_DIR_ENTRY_WIDTH]) {
+        done = 1;
+        break;
+      }
+    }
+
+    if (done) {
+      break;
+    }
+
+    dir_idx.sector++;
+    if (dir_idx.sector == pinfo.sectors_per_cluster) {
+      dir_idx.sector = 0;
+
+      // We assume folders are well-formed, meaning that the last entry
+      // is marked as such and thus we can just get the table value.
+      uint32_t tv = 0;
+      if (0 != fat_get_table_value(dir_idx.cluster, &tv)) {
+        printf("[PrintDir] Error retrieving table value for %ld\n",
+               dir_idx.cluster);
+        return 0;
+      }
+      dir_idx.cluster = tv;
+    }
+  }
+
+  printf("\n");
+  return 0;
+}
+
+// Print root directory
+int ptest_print_root_dir() {
+  // Read root folder
+  printf("Root Directory:\n");
+  ptest_print_dir(pinfo.root_dir_cluster);
+
+  return 0;
+}
+
+// Prints a sector of a text file once and then again, one char at a time
+int ptest_fat_read_one_char() {
+  char *path = "REASON";
+  uint8_t test_buf1[512 + 1];
+  uint8_t test_buf2[1 + 1];
+  uint32_t bytes_read = 0;
+
+  printf("\n1. TIME:\n=========\n");
+  for (i = 0; i < 512 + 1; i++) test_buf1[i] = 0;
+  int fd = fat_open(path, O_RDWR);
+  printf("FD = %d\n", fd);
+
+  for (i = 0; i < 3; i++) {
+    bytes_read = fat_read(fd, test_buf1, 512);
+    printf("%s", test_buf1);
+  }
+
+  printf("\n2. TIME:\n=========\n");
+  test_buf2[1] = 0;
+  fd = fat_open(path, O_RDWR);
+  printf("FD = %d\n", fd);
+
+  // Read entire file, one char at a time
+  for (i = 0; i < 362462; i++) {
+    bytes_read = fat_read(fd, test_buf2, 1);
+    printf("%s", test_buf2);
+  }
+
+  return 0;
+}
+
+// Test disk_read and disk_write
+int ptest_disk_read_write() {
+  int i;
+  uint8_t buf_big[3*512 + 1];
+  uint8_t buf_mid[512 + 1];
+
+  buf_big[3*512] = 0;
+  buf_mid[512] = 0;
+
+  uint32_t offset_sector = fat_first_sector_of_cluster(189); // REASON file
+
+  // Big chunk to compare against
+  printf("Big chunk:\n===========================\n");
+  disk_read(offset_sector, buf_big, 3);
+  printf("%s", buf_big);
+  printf("\n");
+
+  // Chunked big chunk
+  printf("Chunked:\n===========================\n");
+  for (i = 0; i < 3*512 / 512; i++) {
+    disk_read(offset_sector + i, buf_mid, 1);
+    printf("|%d|%s", i, buf_mid);
+  }
+  printf("\n");
+
+  // Make changes across boundary
+  uint32_t write_offset = offset_sector + 1;
+  uint8_t *token_begin = (uint8_t *)"| WRITE BEGIN |"; // 15 chars
+  uint8_t *token_end = (uint8_t *)"| WRITE END |"; // 13 chars
+  uint8_t buf_bak[512];
+
+  disk_read(write_offset, buf_mid, 1);
+  memcpy(buf_bak, buf_mid, 512); // Save edited region for restoration
+  memcpy(buf_mid, token_begin, 15);
+  memcpy(buf_mid + 512 - 13, token_end, 13);
+  disk_write(write_offset, buf_mid, 1);
+
+  // Read out big chunk again for comparison
+  printf("Big chunk modified:\n===========================\n");
+  disk_read(offset_sector, buf_big, 3);
+  printf("%s", buf_big);
+  printf("\n");
+
+  // Restore edited region
+  disk_write(write_offset, buf_bak, 1);
+
+  return 0;
+}
+
+int ptest_write_file() {
+  uint8_t buf_mid[512 + 1];
+  buf_mid[512] = 0;
+
+  char *path = "REASON";
+  uint32_t fd = fat_open(path, O_RDWR);
+
+  fat_lseek(fd, 0, SEEK_SET);
+  fat_read(fd, buf_mid, 512);
+  printf("Original:\n===========================\n");
+  printf("%s", buf_mid);
+
+  printf("\n");
+  memcpy(buffer, buf_mid, 512);
+  memcpy(buffer + 0, path, 6);
+  memcpy(buffer + 128, path, 6);
+  memcpy(buffer + 256 - 6, path, 6);
+  fat_lseek(fd, 0, SEEK_SET);
+  fat_write(fd, buffer, 512);
+
+  fat_lseek(fd, 0, SEEK_SET);
+  fat_read(fd, buf_mid, 512);
+  printf("Original:\n===========================\n");
+  printf("%s", buf_mid);
+
+  printf("\n");
+
+  return 0;
+}
+
+// Print a sector of the FAT
+int ptest_print_fat() {
+  uint8_t buf[fat_pinfo.bytes_per_sector];
+
+  uint32_t sec_off = 1;
+  uint32_t sec = pinfo.fat_begin_addr + sec_off;
+
+  uint32_t entries_per_sector = fat_pinfo.bytes_per_sector / 4;
+
+  uint32_t c = 0; // Cluster
+  uint32_t v = 0; // Value from table
+  uint32_t i = 0;
+
+  printf("FAT Sector %ld:\n\n", sec_off);
+  for (i = 0; i < entries_per_sector; i++) {
+    c = i + sec_off * fat_pinfo.bytes_per_sector / 4;
+    v = fat_get_uint32(buf + 4 * i) & 0x0FFFFFFF;
+    printf("%3ld: %ld -> %ld\n", i, c, v);
+  }
+
+  printf("\n");
+
+  return 0;
+}
+
+int ptest_fat_write_file() {
+  int fd1, fd2;
+  char path1[] = "REASON";
+  char path2[] = "FIRSTFILE";
+
+  uint32_t sz = 512;
+  uint8_t buf[sz + 1];
+  buf[sz] = 0;
+
+  // Open files
+  fd1 = fat_open(path1, O_RDWR);
+  fd2 = fat_open(path2, O_RDWR);
+  printf("Opened %s (FD = %d)\n", path1, fd1);
+  printf("Opened %s (FD = %d)\n", path2, fd2);
+
+  // Read something
+  fat_read(fd1, buf, sz);
+  printf("%s\n", buf);
+
+  // Write it
+  FatFile *f = &fat_open_files[fd2 - FAT_FD_OFFSET];
+  printf("Writing to %s [Sz=%ld Pos=%ld Clus=%ld]\n",
+         path2, f->size, f->pos, f->current_cluster);
+  printf("Dir Entry [Cluster = %ld Sector=%ld Index=%ld]\n",
+         f->dir_idx.cluster, f->dir_idx.sector, f->dir_idx.index);
+
+  /*
+  // Search to end
+  fat_lseek(fd2, 0, SEEK_END);
+  if (0 != errno) {
+    printf("Failed seeking! Errno=%d\n", errno);
+    return 1;
+  }
+  printf("Searched to end in %s [Sz=%ld Pos=%ld CurCluster=%ld]\n",
+         path2, f->size, f->pos, f->current_cluster);
+  */
+
+  /*
+  // Search to start
+  fat_lseek(fd2, 0, SEEK_SET);
+  if (0 != errno) {
+    printf("Failed seeking! Errno=%d\n", errno);
+    return 1;
+  }
+  printf("Searched to beginning in %s [Sz=%ld Pos=%ld CurCluster=%ld]\n",
+         path2, f->size, f->pos, f->current_cluster);
+  */
+
+  // Write
+  uint32_t clusters_to_write = 2 * 1024; // 1MB
+
+  buf[0] = '[';
+  buf[2] = ']';
+  uint32_t i = 0;
+  for (i = 0; i < 64 + 2; i++) {
+    buf[1] = '0' + (i % 10);
+    if (sz != fat_write(fd2, buf, sz)) {
+      printf("Failed writing! Errno=%d\n", errno);
+      return 1;
+    }
+  }
+  printf("\nDone writing to %s [Sz=%ld Pos=%ld Clus=%ld]\n",
+         path2, f->size, f->pos, f->current_cluster);
+
+  printf("\n");
+
+  return 0;
+}
+
+int ptest_fat_print_file(char *path) {
+  int fd;
+
+  // Open file
+  fd = fat_open(path, O_RDWR);
+  if (fd < 0) {
+    int err = errno;
+    printf("Error opening %s (FD = %d). Errno=%d\n", path, fd, err);
+    return 1;
+  }
+
+  // Read something
+  uint32_t rsz = 512;
+  uint32_t sz = 512;
+  do {
+    sz = fat_read(fd, buffer, sz);
+    printf("%s", buffer);
+  } while (sz == rsz);
+  printf("\n");
+
+  fat_close(fd);
+
+  return 0;
+}
+
+// Writes ascending numbers to a file and read them back and verifies them
+int test_fat_write_and_verify(int fd, uint32_t sz, int wrsz) {
+  int i;
+  uint8_t buf[wrsz + 1];
+
+  // Write numbers
+  uint32_t written = 0;
+  while (written < sz) {
+    sprintf((char *)buf, "%06d\n", i++); // Ensure this is wrsz characters
+    if (wrsz != fat_write(fd, buf, wrsz)) {
+      printf("[TEST] Failed writing: Errno=%d\n", errno);
+      return 1;
+    }
+    written += wrsz;
+  }
+
+  // Seek to beginning
+  if (0 != fat_lseek(fd, 0, SEEK_SET)) {
+    printf("[TEST] Error seeking to start in (FD=%d): Errno=%d\n", fd, errno);
+    return 1;
+  }
+
+  // Read numbers back
+  uint32_t read = 0;
+  i = 0;
+  uint32_t v;
+  char *ptr; // Needed for strtol
+  while (read < written) {
+    if (wrsz != fat_read(fd, buf, wrsz) && read < written) {
+      printf("[TEST] Error reading (FD=%d): Errno=%d Written=%ld Read=%ld\n",
+             fd, errno, written, read);
+      return 1;
+    }
+    read += wrsz;
+
+    // Verify numbers
+    v = strtol((char *)buf, &ptr, 10);
+    if (v != i++) {
+      printf("[TEST] Error in (FD=%d): Line=%d but Value=%ld\n", fd, i, v);
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+// Writes a long chain of numbers to a file, and verifies them afterwards
+int test_fat_write_read_numbers_limit(char *path, uint32_t limit, int oflag) {
+  int fd;
+  uint32_t wr_sz = 7; // 6 chars + \n
+  //uint32_t limit = wr_sz * 10;
+  uint8_t buf[wr_sz + 1];
+
+  // Open file
+  fd = fat_open(path, oflag | O_RDWR);
+  if (fd < 0) {
+    printf("[TEST] Error opening %s\n", path);
+    return 1;
+  }
+
+  // Write numbers
+  uint32_t written = 0;
+  uint32_t i = 0;
+  while (written < limit) {
+    sprintf((char *)buf, "%06ld\n", i++); // Ensure this is wr_sz characters
+    if (wr_sz != fat_write(fd, buf, wr_sz)) {
+      printf("[TEST] Failed writing: Errno=%d\n", errno);
+      return 1;
+    }
+    written += wr_sz;
+  }
+
+  // Seek to beginning
+  if (0 != fat_lseek(fd, 0, SEEK_SET)) {
+    printf("[TEST] Error seeking to start in %s (FD=%d): Errno=%d\n", path, fd, errno);
+    return 1;
+  }
+
+  // Read numbers back
+  uint32_t read = 0;
+  i = 0;
+  uint32_t v;
+  char *ptr; // Needed for strtol
+  while (read < written) {
+    if (wr_sz != fat_read(fd, buf, wr_sz) && read < written) {
+      printf("[TEST] Error reading %s (FD=%d): Errno=%d Written=%ld Read=%ld\n",
+             path, fd, errno, written, read);
+      return 1;
+    }
+    read += wr_sz;
+
+    // Verify numbers
+    v = strtol((char *)buf, &ptr, 10);
+    if (v != i++) {
+      printf("[TEST] Error in %s (FD=%d): Line=%ld but Value=%ld\n", path, fd, i, v);
+      return 1;
+    }
+  }
+
+  if (0 != fat_close(fd)) {
+    printf("[TEST] Error in closing %s (FD=%d)\n", path, fd);
+    return 1;
+  }
+
+  printf("[TEST] Successfully wrote and verified %ld lines (%ld bytes) in %s (FD=%d).\n",
+         i, read, path, fd);
+  return 0;
+}
+int test_fat_write_read_numbers(char *path) {
+  uint32_t limit = 3 * pinfo.sectors_per_cluster * pinfo.bytes_per_sector;
+  return test_fat_write_read_numbers_limit(path, limit, O_RDWR);
+}
+
+// Prints the cluster chain beginning a cluster
+int ptest_fat_values(uint32_t cluster) {
+  uint32_t tv = 0;
+
+  uint32_t i = 0;
+  do {
+    if (0 != fat_get_table_value(cluster, &tv)) {
+      printf("Error getting table value: Errno=%d Cluster=%ld\n", errno, cluster);
+      break;
+    }
+    else if (FAT_TV_BAD(tv)) {
+      printf("BAD Value %ld from %ld\n", tv, cluster);
+      return 1;
+    }
+    else if (FAT_TV_FREE(tv)) {
+      printf("FREE Value %ld from %ld\n", tv, cluster);
+      return 1;
+    }
+    else {
+      printf("Cluster %ld -> %ld\n", cluster, tv);
+    }
+
+    cluster = tv;
+  } while (!FAT_TV_LAST(tv));
+
+  return 0;
+}
+
+// Print FAT table values between two clusters
+int ptest_fat_table(uint32_t start_cluster, uint32_t end_cluster) {
+  uint32_t cur_sec = 0;
+  uint32_t cur_ent = 0;
+  uint32_t cur_tv = 0;
+  uint32_t fat_start = pinfo.fat_begin_addr;
+
+  uint32_t entries_per_sector = pinfo.bytes_per_sector / 4;
+  uint8_t buf[pinfo.bytes_per_sector];
+
+  uint32_t sec_start = 4 * start_cluster / pinfo.bytes_per_sector;
+  uint32_t sec_end = 4 * end_cluster / pinfo.bytes_per_sector;
+  uint32_t secs = sec_end - sec_start;
+
+  uint32_t i, j;
+  for (i = 0; i < secs; i++) { // Loop through sectors
+    cur_sec = sec_start + i;
+    disk_read(fat_start + cur_sec, buf, 1);
+    for (j = 0; j < entries_per_sector; j++) { // Loop through entries
+      cur_ent = cur_sec * entries_per_sector + j;
+      cur_tv = fat_get_uint32(buf + 4 * j) & 0x0FFFFFFF;
+      printf("%ld -> %ld\n", cur_ent, cur_tv);
+    }
+  }
+
+  return 0;
+}
+
+// Writes and verifies number in a file, prints the cluster chain,
+// deletes the file and does it to the test file just before.
+// Read output to verify they occupy same clusters.
+int ptest_fat_unlink(char *path) {
+  FatFile *f = 0;
+  int fd = 0;
+
+  // 1. Write multiple clusters to test file n
+  if (0 != test_fat_write_read_numbers(path)) {
+    printf("[TEST] Aborted due to error in writing numbers to \"%s\"\n", path);
+    return 1;
+  }
+
+  // 2. Print clusters of file n
+  fd = fat_open(path, O_RDWR);
+  if (fd < 0) {
+    printf("[TEST] Aborted due to error in opening file \"%s\"\n", path);
+    return 1;
+  }
+  f = &fat_open_files[fd - FAT_FD_OFFSET];
+  if (0 != ptest_fat_values(f->start_cluster)) {
+    printf("[TEST] Aborted due to error in printing cluster chain of \"%s\" (FD=%d)\n",
+           path, fd);
+    return 1;
+  }
+  if (0 != fat_close(fd)) {
+    printf("[TEST] Aborted due to error in closing file \"%s\" (FD=%d)\n", path, fd);
+    return 1;
+  }
+
+  // 3. Unlink file n
+   if (0 != fat_unlink(path)) {
+    printf("[TEST] Aborted due to error in unlinking file \"%s\"\n", path);
+    return 1;
+  }
+  printf("[TEST] Successfully unlinked file \"%s\"\n", path);
+
+  // 4. Write multiple clusters to test file n-1
+  if (0 != test_fat_write_read_numbers(path)) {
+    printf("[TEST] Aborted due to error in writing numbers to \"%s\"\n", path);
+    return 1;
+  }
+
+  // 5. Print clusters of file n-1
+  fd = fat_open(path, O_RDWR);
+  if (fd < 0) {
+    printf("[TEST] Aborted due to error in opening file \"%s\"\n", path);
+    return 1;
+  }
+  f = &fat_open_files[fd - FAT_FD_OFFSET];
+  if (0 != ptest_fat_values(f->start_cluster)) {
+    printf("[TEST] Aborted due to error in printing cluster chain of \"%s\" (FD=%d)\n",
+           path, fd);
+    return 1;
+  }
+  if (0 != fat_close(fd)) {
+    printf("[TEST] Aborted due to error in closing file \"%s\" (FD=%d)\n", path, fd);
+    return 1;
+  }
+
+  // NOTE: File n-1 should occupy the same clusters as file n did
+  return 0;
+}
+
+// Performs above test on multiple files
+int ptest_unlink_many(char *format_path, int minidx, int maxidx) {
+  char path[256];
+
+  int i = 0;
+  for (i = maxidx; i >= minidx; --i) {
+    sprintf(path, format_path, i);
+    if (0 != ptest_fat_unlink(format_path)) {
+      printf("Errno=%d\n", errno);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+// Creates a file
+int ptest_create(char *path) {
+  int fd;
+
+  fd = fat_open(path, O_CREAT);
+  if (fd < 0) {
+    printf("[TEST] Aborted due to error in creating file \"%s\"\n", path);
+    return 1;
+  }
+  fat_close(fd);
+
+  test_fat_write_read_numbers(path);
+
+  return 0;
+}
+
+// Create enough files to extend the folder by a cluster.
+// Write and verify a tiny amount in each folder.
+// Takes a sprintf format path as argument, that must have exactly one %d.
+int ptest_create_many(char *format_path) {
+  int fd;
+  int i;
+  char path[256];
+
+  int entries = 1 + (fat_pinfo.sectors_per_cluster * fat_pinfo.bytes_per_sector / 32);
+  int verify_sz = 16;
+
+  // Generate random-ish name
+  const uint8_t c_min = 'A';
+  const uint8_t c_max = 'Z';
+  uint8_t rand = 0x36;
+  int k;
+
+  for (i = 0; i < 256; i++)
+    path[i] = 0; // Empty array
+
+  for (i = 0; i < entries; i++) {
+    sprintf(path, format_path, i);
+    for (k = 0; '.' != path[k]; k++) {
+      rand ^= path[k] ^ i;
+      path[k] = c_min + (rand % (c_max - c_min));
+    }
+
+    fd = fat_open(path, O_CREAT | O_EXCL);
+    if (fd < 0 || errno != 0) {
+      /*
+      printf("[TEST] Aborted due to error in creating file \"%s\": %d\n",
+             path, errno);
+      return 1;
+      */
+      printf("[TEST] Skipped due to error in creating file \"%s\": %d\n",
+             path, errno);
+      continue;
+    }
+    fat_close(fd);
+
+    if (0 != test_fat_write_read_numbers_limit(path, verify_sz, O_RDWR)) {
+      printf("[TEST] Aborted due to error in verifying file \"%s\": %d\n",
+             path, errno);
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+// Create a file in a folder
+int ptest_create_in_folder(char *dir_path, char *file_name) {
+  int fd;
+  int verify_sz = 16;
+  char path[256];
+
+  // Create folder
+  if (FAT_SUCCESS == fat_mkdir(dir_path)) {
+    printf("[TEST] Successfully created folder \"%s\"\n", dir_path);
+  }
+  else {
+    /*
+    printf("[TEST] Aborted due to error in creating folder \"%s\": %d\n",
+            path, errno);
+    return 1;
+    */
+    printf("[TEST] Folder \"%s\" already existed\n", dir_path);
+  }
+
+  // Create file
+  sprintf(path, "%s/%s", dir_path, file_name);
+  fd = fat_open(path, O_CREAT | O_EXCL);
+  if (fd < 0 || errno != 0) {
+    printf("[TEST] Aborted due to error in creating file \"%s\": %d\n",
+          path, errno);
+    return 1;
+  }
+  fat_close(fd);
+
+  // Verify
+  if (0 != test_fat_write_read_numbers_limit(path, verify_sz, O_RDWR)) {
+    printf("[TEST] Aborted due to error in verifying file \"%s\": %d\n",
+          path, errno);
+    return 1;
+  }
+
+  return 0;
+}
+
+// Create a tree of folders with files in the leaf folders
+// Write and verify a tiny amount in each leaf file.
+// Takes a sprintf format path as argument, that must have exactly /two/ %d.
+int ptest_create_tree(char *format_path, int height, int width) {
+  int fd;
+  int j, k;
+  char path[256];
+  int verify_sz = 16;
+
+  for (i = 0; i < 256; i++) {
+    path[i] = 0;
+  }
+
+  uint32_t name_begin = 0;
+  uint32_t path_len = 0;
+
+  for (j = 0; j < width; j++) {
+    // Create path
+    sprintf(path, format_path, height, j);
+
+    for (k = 0; k < 256; k++) {
+      if (path[k] == '/') {
+        name_begin = k + 1;
+      }
+      if (path[k] == 0) {
+        path_len = k;
+        break;
+      }
+    }
+    if (k == 256 | path_len >= 256) {
+      printf("[TEST] Aborted due to path being too long \"%s\"\n", path);
+      return 1;
+    }
+
+    // Create files / folders
+    if (height > 0) { // Creating folders
+      if (FAT_SUCCESS == fat_mkdir(path)) {
+        printf("[TEST] Successfully created folder \"%s\"\n", path);
+
+        // Recurse
+        path[path_len] = '/';
+        path_len++;
+        memcpy(path + path_len, format_path + name_begin, path_len - name_begin + 1);
+        ptest_create_tree(path, height - 1, width);
+      }
+      else {
+        printf("[TEST] Aborted due to error in creating folder \"%s\": %d\n",
+              path, errno);
+        return 1;
+      }
+    }
+    else { // Creating leaves
+      fd = fat_open(path, O_CREAT | O_EXCL);
+      if (fd < 0 || errno != 0) {
+        printf("[TEST] Skipped due to error in creating file \"%s\": %d\n",
+              path, errno);
+        continue;
+      }
+      fat_close(fd);
+
+      if (0 != test_fat_write_read_numbers_limit(path, verify_sz, O_RDWR)) {
+        printf("[TEST] Aborted due to error in verifying file \"%s\": %d\n",
+              path, errno);
+        return 1;
+      }
+    }
+  }
+
+  return 0;
+}
+
+// A composite test that covers many features:
+// 1. Create new directory
+// 2. Create files in directory, writing and verifying data in each
+// 3. Delete all the files
+// 4. Delete now empty folder
+int test_fat_create_verify_delete(char *dirpath, char *fpath, int n, int sz) {
+  int i;
+  int fd;
+  char path[256];
+
+  // Create directory
+  if (FAT_SUCCESS != fat_mkdir(dirpath)) {
+    printf("[TEST] Error in creating folder \"%s\": %d\n", dirpath, errno);
+  }
+
+  // Create files
+  for (i = 0; i < n; i++) {
+    sprintf(path, fpath, i);
+    fd = fat_open(path, O_CREAT | O_EXCL);
+    if (fd < 0) {
+      printf("[TEST] Error in creating file \"%s\": %d\n", path, errno);
+    }
+    if (0 != fat_close(fd)) {
+      printf("[TEST] Error in closing file \"%s\": %d\n", path, errno);
+      break;
+    }
+
+    // Verify
+    if (0 != test_fat_write_read_numbers_limit(path, sz, 0)) {
+      break;
+    }
+  }
+
+  // Delete all the files
+  for (i = 0; i < n; i++) {
+    sprintf(path, fpath, i);
+
+    if (0 != fat_unlink(path)) {
+      printf("[TEST] Error in deleting file \"%s\": %d\n", path, errno);
+      break;
+    }
+  }
+
+  // Delete the folder
+  if (0 != fat_rmdir(dirpath)) {
+    printf("[TEST] Error in deleting folder \"%s\": %d\n", dirpath, errno);
+    return 1;
+  }
+
+  return 0; // TODO: Return error on failure
+}
+
+int main() {
+  int errsv = 0;
+
+  printf("\n");
+
+  // Initialize card
+  if (0 != disk_init()) {
+    errsv = errno;
+    printf("Error initializing SD card! Errno=%d\n", errsv);
+    return errsv;
+  }
+  printf("Card initialized\n");
+
+  // Load partition info
+  if (0 != fat_load_first_partition_info(&pinfo)) {
+    errsv = errno;
+    printf("Error loading FAT partition! Errno = %d\n", errsv);
+    return errsv;
+  };
+  printf("PartitionInfo loaded\n");
+
+  // Initialize FAT
+  if (0 != fat_init(&pinfo)) {
+    errsv = errno;
+    printf("Error initializing FAT! Errno = %d\n", errsv);
+    return errsv;
+  }
+  printf("FAT initialized\n");
+
+  // Print tests
+  ptest_pinfo();
+  ptest_print_root_dir();
+  test_fat_create_verify_delete("TempDir", "TempDir/LongFileName%d", 2, 5);
+
+  return 0;
+}

--- a/c/sdtime.c
+++ b/c/sdtime.c
@@ -1,0 +1,388 @@
+/*
+   Copyright 2017 Max Rishoej Pedersen
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+
+         this list of conditions and the following disclaimer.
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * File for timing FAT32 on SD card.
+ *
+ * Authors: Max Rishoej (maxrishoej@gmail.com)
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <machine/spm.h>
+
+// NOTE: Source files are imported here, not headers.
+// This is to access functions otherwise hidden.
+#include "libsd/sddisk.c"
+#include "libsd/fat32.c"
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+// Reused fields
+uint8_t res; // Response from SD card
+uint8_t buffer[512];
+FatPartitionInfo pinfo;
+int i;
+
+// Prints timing of disk reads
+int ptest_time_disk_read(uint32_t sz) {
+  uint8_t buf[512 + 1];
+
+  printf("[TIME] Reading %ld bytes: ", sz);
+  clock_t begin = clock();
+
+  uint32_t sec = fat_first_sector_of_cluster(pinfo.root_dir_cluster);
+  uint32_t secs = sz / pinfo.bytes_per_sector;
+
+  do {
+    disk_read(sec++, buf, 1);
+    secs--;
+  } while (secs > 0);
+
+  clock_t end = clock();
+  double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+  printf("%fs\n", time_spent);
+
+  return 0;
+}
+
+// Prints timing of disk writes
+int ptest_time_disk_write(uint32_t sz) {
+  uint8_t buf[512 + 1];
+
+  printf("[TIME] Writing %ld bytes: ", sz);
+  clock_t begin = clock();
+
+  uint32_t sec = fat_first_sector_of_cluster(1000); // Arbitrary number
+  uint32_t secs = sz / pinfo.bytes_per_sector;
+
+  do {
+    disk_write(sec++, buf, 1);
+    secs--;
+  } while (secs > 0);
+
+  clock_t end = clock();
+  double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+  printf("%fs\n", time_spent);
+
+  return 0;
+}
+
+// Prints timing of file writes
+// Only times writing, not creation / opening / closing
+int ptest_time_fat_write(char *path, uint32_t wrsz, uint32_t sz, uint32_t off) {
+  uint8_t buf[512 + 1];
+  int fd;
+
+  // Create file if it does not exist
+  fd = fat_open(path, O_RDWR | O_CREAT);
+  if (fd < 0) {
+    printf("[TIME] Aborted due to error in opening file \"%s\": %d\n", path, errno);
+    return 1;
+  }
+
+  // Offset
+  if (off != fat_write(fd, buf, off)) {
+    printf("[TIME] Aborted due to error when writing %ld offset bytes in file \"%s\": %d\n", off, path, errno);
+    return 1;
+  }
+
+  printf("[TIME] Writing %ld bytes to \"%s\" in %ld chunks: ", sz, path, wrsz);
+  clock_t begin = clock();
+  uint32_t td = 0;
+
+  do {
+    td += fat_write(fd, buf, wrsz);
+  } while (td < sz);
+
+  clock_t end = clock();
+  double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+  printf("%fs\n", time_spent);
+
+  // Close file
+  fat_close(fd);
+
+  return 0;
+}
+
+int ptest_time_fat_read(char *path, uint32_t rdsz, uint32_t sz, uint32_t off) {
+  uint8_t buf[512 + 1];
+  int fd;
+
+  // Create file if it does not exist
+  fd = fat_open(path, O_RDWR);
+  if (fd < 0) {
+    printf("[TIME] Aborted due to error in opening file \"%s\": %d\n", path, errno);
+    return 1;
+  }
+
+  // Offset the cursor
+  if (off != fat_lseek(fd, off, SEEK_SET)) {
+    printf("[TIME] Aborted due to error when seeking to %ld in file \"%s\": %d\n", off, path, errno);
+    return 1;
+  }
+
+  printf("[TIME] Reading %ld bytes from \"%s\" in %ld chunks: ", sz, path, rdsz);
+  clock_t begin = clock();
+  uint32_t td = 0;
+
+  do {
+    td += fat_read(fd, buf, rdsz);
+  } while (td < sz);
+
+  clock_t end = clock();
+  double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+  printf("%fs\n", time_spent);
+
+  // Close file
+  fat_close(fd);
+
+  return td < sz;
+}
+
+// Times creating a lot of small files in a folder
+int ptest_time_fat_create_many(char *dirpath, char *filepath, int n) {
+  int i;
+  int fd;
+
+  // Prepare directory path
+  char fpath[256];
+  sprintf(fpath, dirpath, n);
+
+  // Create directory if it does not exist
+  if (0 != fat_mkdir(fpath)) {
+    printf("[TIME] Aborted due to error in creating folder \"%s\": %d\n", fpath, errno);
+  }
+  printf("[TIME] Creating %d files in directory \"%s\": ", n, fpath);
+
+  // Setup full format path
+  sprintf(fpath, "%s/%s", fpath, filepath);
+  char path[256];
+
+  // Begin clock
+  clock_t begin = clock();
+
+  while (n > 0) {
+    sprintf(path, fpath, n);
+    fd = fat_open(path, O_CREAT | O_EXCL);
+    if (fd < 0) {
+      break;
+    }
+    if (0 != fat_close(fd)) {
+      break;
+    }
+
+    n--;
+  }
+
+  clock_t end = clock();
+  double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+  printf("%fs\n", time_spent);
+
+  return n ? 1 : 0;
+}
+
+// Deletes a single file that already exists
+int ptest_time_deletion_single(char *path) {
+  // Time and delete the file
+  clock_t begin = clock();
+
+  if (0 != fat_unlink(path)) {
+    printf("[TEST] Error in deleting file \"%s\": %d\n", path, errno);
+    return 1;
+  }
+
+  clock_t end = clock();
+  double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+  printf("[TIME] Deleted \"%s\": %f\n", path, time_spent);
+
+  return 0;
+}
+
+// Times the deletion of a single large file that is created before timing
+int ptest_time_deletion_single_create(char *dirpath, char *fpath, int sz) {
+  int i;
+  int fd;
+  uint8_t buf[512];
+  char path[256];
+
+  // Create directory
+  if (FAT_SUCCESS != fat_mkdir(dirpath)) {
+    printf("[TEST] Error in creating folder \"%s\": %d\n", dirpath, errno);
+  }
+
+  // Create file
+  sprintf(path, fpath, i);
+  fd = fat_open(path, O_CREAT | O_EXCL);
+  if (fd < 0) {
+    printf("[TEST] Error in creating file \"%s\": %d\n", path, errno);
+  }
+
+  // Write to file
+  uint32_t td = 0;
+  do {
+    td += fat_write(fd, buf, 512);
+  } while (td < sz);
+
+  if (0 != fat_close(fd)) {
+    printf("[TEST] Error in closing file \"%s\": %d\n", path, errno);
+    return 1;
+  }
+
+  printf("[TEST] File \"%s\" (size = %d) created\n", path, sz);
+
+  // Time and delete the file
+  ptest_time_deletion_single(path);
+
+  // Delete the folder
+  if (0 != fat_rmdir(dirpath)) {
+    printf("[TEST] Error in deleting folder \"%s\": %d\n", dirpath, errno);
+    return 1;
+  }
+
+  return 0; // TODO: Return error on failure
+}
+
+// Times deletion of many existing files
+int ptest_time_deletion_many(char *fpath, int n) {
+  int i;
+  char path[256];
+
+  // Time and delete the file
+  int num = n;
+  clock_t begin = clock();
+
+  while (n > 0) {
+    sprintf(path, fpath, n);
+    if (0 != fat_unlink(path)) {
+      printf("[TEST] Error in deleting file \"%s\": %d\n", path, errno);
+      return 1;
+    }
+    n--;
+  }
+
+  clock_t end = clock();
+  double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+  printf("[TIME] Deleted %d files: %f\n", num, time_spent);
+
+  return n == 0;
+}
+
+int main() {
+  int errsv = 0;
+
+  printf("\n");
+
+  // Initialize card
+  if (0 != disk_init()) {
+    errsv = errno;
+    printf("Error initializing SD card! Errno=%d\n", errsv);
+    return errsv;
+  }
+  printf("Card initialized\n");
+
+  // Load partition info
+  if (0 != fat_load_first_partition_info(&pinfo)) {
+    errsv = errno;
+    printf("Error loading FAT partition! Errno = %d\n", errsv);
+    return errsv;
+  };
+  printf("PartitionInfo loaded\n");
+
+  // Initialize FAT
+  if (0 != fat_init(&pinfo)) {
+    errsv = errno;
+    printf("Error initializing FAT! Errno = %d\n", errsv);
+    return errsv;
+  }
+  printf("FAT initialized\n");
+
+  // --- Tests ---
+  /*
+  for (i = 1; i < 128; i *= 2) {
+    if (0 != ptest_time_fat_read("szone/sz128", 512, i * 1000 * 1000, 3)) {
+      printf("[TIME] Aborted due to incomplete test with %d megabytes\n", i);
+      break;
+    }
+  }
+  */
+
+  /*
+  for (i = 1; i <= 2048; i *= 2) {
+    if (0 != ptest_time_fat_create_many("L%d", "F0123456789ABCDEF%d", i)) {
+      printf("[TIME] Aborted due to incomplete test with %d files\n", i);
+      break;
+    }
+  }
+  */
+
+  /*
+  for (i = 1; i <= 128; i *= 2) {
+    if (0 != ptest_time_deletion_single_create("SzOne/Time0.txt", 1000 * 1000 * i)) {
+      printf("[TIME] Aborted due to incomplete test with %d bytes\n", i);
+    }
+  }
+  */
+
+  /*
+  ptest_time_deletion_single("SzOne/Sz1");
+  ptest_time_deletion_single("SzOne/Sz2");
+  ptest_time_deletion_single("SzOne/Sz4");
+  ptest_time_deletion_single("SzOne/Sz8");
+  ptest_time_deletion_single("SzOne/Sz16");
+  ptest_time_deletion_single("SzOne/Sz32");
+  ptest_time_deletion_single("SzOne/Sz64");
+  ptest_time_deletion_single("SzOne/Sz128");
+  */
+
+  /*
+  ptest_time_deletion_many("SzMany/D1/F%d", 1);
+  ptest_time_deletion_many("SzMany/D2/F%d", 2);
+  ptest_time_deletion_many("SzMany/D4/F%d", 4);
+  ptest_time_deletion_many("SzMany/D8/F%d", 8);
+  ptest_time_deletion_many("SzMany/D16/F%d", 16);
+  ptest_time_deletion_many("SzMany/D32/F%d", 32);
+  ptest_time_deletion_many("SzMany/D64/F%d", 64);
+  ptest_time_deletion_many("SzMany/D128/F%d", 128);
+  ptest_time_deletion_many("SzMany/D256/F%d", 256);
+  ptest_time_deletion_many("SzMany/D512/F%d", 512);
+  ptest_time_deletion_many("SzMany/D1024/F%d", 1024);
+  */
+
+  return 0;
+}

--- a/hardware/config/altde2-115-sd.xml
+++ b/hardware/config/altde2-115-sd.xml
@@ -1,0 +1,44 @@
+<patmos default="default.xml">
+  <description>configuration for DE2-115 board with SD card port in SPI mode</description>
+
+  <frequency Hz="80000000"/>
+
+  <ExtMem size="2M" DevTypeRef="Sram16" />
+
+  <IOs>
+	<IO DevTypeRef="Uart" offset="8"/>
+	<IO DevTypeRef="Leds" offset="9"/>
+	<IO DevTypeRef="Keys" offset="10" intrs="2,3,4,5"/>
+	<IO DevTypeRef="SDHostCtrl" offset="11"/>
+  </IOs>
+
+  <Devs>
+  	<Dev DevType="Uart" entity="Uart" iface="OcpCore">
+  	  <params>
+  		<param name="baudRate" value="115200"/>
+  		<param name="fifoDepth" value="16"/>
+  	  </params>
+  	</Dev>
+  	<Dev DevType="Leds" entity="Leds" iface="OcpCore">
+  	  <params>
+  		<param name="ledCount" value="9"/>
+  	  </params>
+  	</Dev>
+  	<Dev DevType="Keys" entity="Keys" iface="OcpCore">
+  	  <params>
+  		<param name="keyCount" value="4"/>
+  	  </params>
+  	</Dev>
+  	<Dev DevType="SDHostCtrl" entity="SDHostCtrl" iface="OcpCore">
+  	  <params>
+  	  </params>
+  	</Dev> 
+    <Dev DevType="Sram16" entity="SRamCtrl" iface="OcpBurst">
+        <params>
+            <param name="ocpAddrWidth" value="21" />
+            <param name="sramAddrWidth" value="20" />
+            <param name="sramDataWidth" value="16" />
+        </params>
+    </Dev>
+  </Devs>
+</patmos>

--- a/hardware/quartus/altde2-115-sd/patmos.qpf
+++ b/hardware/quartus/altde2-115-sd/patmos.qpf
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 1991-2010 Altera Corporation
+# Your use of Altera Corporation's design tools, logic functions 
+# and other software and tools, and its AMPP partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Altera Program License 
+# Subscription Agreement, Altera MegaCore Function License 
+# Agreement, or other applicable license agreement, including, 
+# without limitation, that your use is for the sole purpose of 
+# programming logic devices manufactured by Altera and sold by 
+# Altera or its authorized distributors.  Please refer to the 
+# applicable agreement for further details.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus II
+# Version 10.1 Build 153 11/29/2010 SJ Web Edition
+# Date created = 04:09:25  January 04, 2013
+#
+# -------------------------------------------------------------------------- #
+
+QUARTUS_VERSION = "10.1"
+DATE = "04:09:25  January 04, 2013"
+
+# Revisions
+
+PROJECT_REVISION = "patmos"

--- a/hardware/quartus/altde2-115-sd/patmos.qsf
+++ b/hardware/quartus/altde2-115-sd/patmos.qsf
@@ -1,0 +1,594 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 1991-2011 Altera Corporation
+# Your use of Altera Corporation's design tools, logic functions
+# and other software and tools, and its AMPP partner logic
+# functions, and any output files from any of the foregoing
+# (including device programming or simulation files), and any
+# associated documentation or information are expressly subject
+# to the terms and conditions of the Altera Program License
+# Subscription Agreement, Altera MegaCore Function License
+# Agreement, or other applicable license agreement, including,
+# without limitation, that your use is for the sole purpose of
+# programming logic devices manufactured by Altera and sold by
+# Altera or its authorized distributors.  Please refer to the
+# applicable agreement for further details.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus II
+# Version 11.0 Build 208 07/03/2011 Service Pack 1 SJ Web Edition
+# Date created = 11:11:57  June 19, 2012
+#
+# -------------------------------------------------------------------------- #
+#
+# Notes:
+#
+# 1) The default values for assignments are stored in the file:
+#		patmos_core_assignment_defaults.qdf
+#    If this file doesn't exist, see file:
+#		assignment_defaults.qdf
+#
+# 2) Altera recommends that you do not modify this file. This
+#    file is updated automatically by the Quartus II software
+#    and any changes you make may be lost or overwritten.
+#
+# -------------------------------------------------------------------------- #
+
+
+set_global_assignment -name FAMILY "Cyclone IV E"
+set_global_assignment -name DEVICE EP4CE115F29C7
+set_global_assignment -name TOP_LEVEL_ENTITY patmos_top
+set_global_assignment -name ORIGINAL_QUARTUS_VERSION "11.0 SP1"
+set_global_assignment -name PROJECT_CREATION_TIME_DATE "11:11:57  JUNE 19, 2012"
+set_global_assignment -name LAST_QUARTUS_VERSION 14.1.0
+
+
+set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
+set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85
+set_global_assignment -name ERROR_CHECK_FREQUENCY_DIVISOR 1
+set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
+set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
+set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
+set_global_assignment -name USE_CONFIGURATION_DEVICE ON
+set_global_assignment -name RESERVE_ALL_UNUSED_PINS "AS INPUT TRI-STATED"
+set_global_assignment -name STRATIX_DEVICE_IO_STANDARD "3.3-V LVCMOS"
+
+
+
+set_global_assignment -name RESERVE_ALL_UNUSED_PINS_NO_OUTPUT_GND "AS INPUT TRI-STATED"
+
+set_location_assignment PIN_Y2 -to clk
+set_location_assignment PIN_T8 -to oSRAM_A[19]
+set_location_assignment PIN_AB8 -to oSRAM_A[18]
+set_location_assignment PIN_AB9 -to oSRAM_A[17]
+set_location_assignment PIN_AC11 -to oSRAM_A[16]
+set_location_assignment PIN_AB11 -to oSRAM_A[15]
+set_location_assignment PIN_AA4 -to oSRAM_A[14]
+set_location_assignment PIN_AC3 -to oSRAM_A[13]
+set_location_assignment PIN_AB4 -to oSRAM_A[12]
+set_location_assignment PIN_AD3 -to oSRAM_A[11]
+set_location_assignment PIN_AF2 -to oSRAM_A[10]
+set_location_assignment PIN_T7 -to oSRAM_A[9]
+set_location_assignment PIN_AF5 -to oSRAM_A[8]
+set_location_assignment PIN_AC5 -to oSRAM_A[7]
+set_location_assignment PIN_AB5 -to oSRAM_A[6]
+set_location_assignment PIN_AE6 -to oSRAM_A[5]
+set_location_assignment PIN_AB6 -to oSRAM_A[4]
+set_location_assignment PIN_AC7 -to oSRAM_A[3]
+set_location_assignment PIN_AE7 -to oSRAM_A[2]
+set_location_assignment PIN_AD7 -to oSRAM_A[1]
+set_location_assignment PIN_AB7 -to oSRAM_A[0]
+set_location_assignment PIN_AD5 -to oSRAM_OE_N
+set_location_assignment PIN_AE8 -to oSRAM_WE_N
+set_location_assignment PIN_AF8 -to oSRAM_CE_N
+set_location_assignment PIN_AD4 -to oSRAM_LB_N
+set_location_assignment PIN_AC4 -to oSRAM_UB_N
+set_location_assignment PIN_AG3 -to SRAM_DQ[15]
+set_location_assignment PIN_AF3 -to SRAM_DQ[14]
+set_location_assignment PIN_AE4 -to SRAM_DQ[13]
+set_location_assignment PIN_AE3 -to SRAM_DQ[12]
+set_location_assignment PIN_AE1 -to SRAM_DQ[11]
+set_location_assignment PIN_AE2 -to SRAM_DQ[10]
+set_location_assignment PIN_AD2 -to SRAM_DQ[9]
+set_location_assignment PIN_AD1 -to SRAM_DQ[8]
+set_location_assignment PIN_AF7 -to SRAM_DQ[7]
+set_location_assignment PIN_AH6 -to SRAM_DQ[6]
+set_location_assignment PIN_AG6 -to SRAM_DQ[5]
+set_location_assignment PIN_AF6 -to SRAM_DQ[4]
+set_location_assignment PIN_AH4 -to SRAM_DQ[3]
+set_location_assignment PIN_AG4 -to SRAM_DQ[2]
+set_location_assignment PIN_AF4 -to SRAM_DQ[1]
+set_location_assignment PIN_AH3 -to SRAM_DQ[0]
+set_location_assignment PIN_G12 -to iUartPins_rxd
+set_location_assignment PIN_G9 -to oUartPins_txd
+set_location_assignment PIN_F17 -to oLedsPins_led[8]
+set_location_assignment PIN_G21 -to oLedsPins_led[7]
+set_location_assignment PIN_G22 -to oLedsPins_led[6]
+set_location_assignment PIN_G20 -to oLedsPins_led[5]
+set_location_assignment PIN_H21 -to oLedsPins_led[4]
+set_location_assignment PIN_E24 -to oLedsPins_led[3]
+set_location_assignment PIN_E25 -to oLedsPins_led[2]
+set_location_assignment PIN_E22 -to oLedsPins_led[1]
+set_location_assignment PIN_E21 -to oLedsPins_led[0]
+set_location_assignment PIN_R24 -to iKeysPins_key[3]
+set_location_assignment PIN_N21 -to iKeysPins_key[2]
+set_location_assignment PIN_M21 -to iKeysPins_key[1]
+set_location_assignment PIN_M23 -to iKeysPins_key[0]
+
+
+set_global_assignment -name SYNTH_TIMING_DRIVEN_SYNTHESIS ON
+set_global_assignment -name CYCLONEII_OPTIMIZATION_TECHNIQUE SPEED
+set_global_assignment -name POWER_PRESET_COOLING_SOLUTION "23 MM HEAT SINK WITH 200 LFPM AIRFLOW"
+set_global_assignment -name POWER_BOARD_THERMAL_MODEL "NONE (CONSERVATIVE)"
+set_global_assignment -name DEVICE_FILTER_PACKAGE FBGA
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_WE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_CE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_LB_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_OE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_UB_N
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to oLedsPins_led[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oUartPins_txd
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SRAM_DQ[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to iUartPins_rxd
+set_instance_assignment -name IO_STANDARD "2.5 V" -to iKeysPins_key[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to iKeysPins_key[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to iKeysPins_key[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to iKeysPins_key[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|addrReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|doutReg"
+set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|doutEnaReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|noeReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|nweReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|nlbReg"
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to "Patmos:comp|SRamCtrl:ramCtrl|nubReg"
+set_global_assignment -name FITTER_EFFORT "STANDARD FIT"
+set_global_assignment -name OPTIMIZE_HOLD_TIMING "ALL PATHS"
+set_global_assignment -name OPTIMIZE_MULTI_CORNER_TIMING ON
+set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC ON
+set_global_assignment -name SEED 6
+set_global_assignment -name VERILOG_MACRO "SYNTHESIS=<None>"
+
+set_global_assignment -name VHDL_FILE "../../vhdl/patmos_de2-115-sd.vhdl"
+set_global_assignment -name VHDL_FILE ../../vhdl/altera/cyc2_pll.vhd
+set_global_assignment -name VERILOG_FILE ../../build/Patmos.v
+set_location_assignment PIN_AE14 -to iSDHostCtrl_do
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to iSDHostCtrl_do
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to iSDHostCtrl_wp
+set_location_assignment PIN_AF14 -to iSDHostCtrl_wp
+set_location_assignment PIN_AE13 -to oSDHostCtrl_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSDHostCtrl_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSDHostCtrl_cs
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSDHostCtrl_di
+set_location_assignment PIN_AC14 -to oSDHostCtrl_cs
+set_location_assignment PIN_AD14 -to oSDHostCtrl_di
+set_global_assignment -name ENABLE_SIGNALTAP ON
+set_global_assignment -name USE_SIGNALTAP_FILE sd_signaltap.stp
+set_global_assignment -name SIGNALTAP_FILE sd_signaltap.stp
+set_global_assignment -name SLD_NODE_CREATOR_ID 110 -section_id default
+set_global_assignment -name SLD_NODE_ENTITY_NAME sld_signaltap -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[0] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[1] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[2] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[3] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[4] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[5] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[6] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[7] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[8] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[9] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[10] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[11] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[12] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[13] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[14] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[15] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[16] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufPntReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[17] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufPntReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[18] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufPntReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[19] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufPntReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[20] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[21] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[22] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[23] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[24] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[25] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[26] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[27] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[28] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[29] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[30] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[31] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[32] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[33] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[34] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[35] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[36] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[37] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[38] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[39] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[40] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[41] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[42] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[43] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[44] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[45] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[46] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[47] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[48] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[49] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[50] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[51] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[52] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkReg" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[53] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|csReg" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[54] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|enReg" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[55] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[56] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[57] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[58] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[59] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[60] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[61] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[62] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[16]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[63] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[17]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[64] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[18]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[65] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[19]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[66] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[67] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[20]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[68] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[21]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[69] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[22]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[70] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[23]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[71] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[24]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[72] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[25]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[73] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[26]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[74] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[27]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[75] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[28]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[76] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[29]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[77] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[78] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[30]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[79] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[31]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[80] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[81] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[82] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[83] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[84] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[85] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[86] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[87] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Cmd[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[88] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Cmd[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[89] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Cmd[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[90] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[91] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[92] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[93] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[94] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[95] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[96] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[97] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[16]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[98] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[17]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[99] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[18]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[100] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[19]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[101] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[102] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[20]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[103] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[21]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[104] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[22]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[105] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[23]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[106] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[24]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[107] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[25]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[108] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[26]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[109] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[27]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[110] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[28]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[111] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[29]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[112] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[113] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[30]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[114] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[31]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[115] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[116] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[117] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[118] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[119] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[120] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[121] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[122] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[123] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[124] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[125] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[126] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[127] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[128] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[129] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[16]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[130] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[17]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[131] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[18]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[132] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[19]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[133] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[134] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[20]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[135] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[21]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[136] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[22]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[137] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[23]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[138] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[24]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[139] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[25]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[140] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[26]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[141] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[27]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[142] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[28]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[143] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[29]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[144] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[145] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[30]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[146] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[31]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[147] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[148] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[149] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[150] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[151] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[152] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[153] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[154] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Resp[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[155] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Resp[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[156] -to iSDHostCtrl_do -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[157] -to iSDHostCtrl_wp -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[158] -to oSDHostCtrl_clk -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[159] -to oSDHostCtrl_cs -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_trigger_in[160] -to oSDHostCtrl_di -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[0] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[1] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[2] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[3] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[4] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[5] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[6] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[7] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufInReg[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[8] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[9] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[10] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[11] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[12] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[13] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[14] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[15] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufOutReg[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[16] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufPntReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[17] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufPntReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[18] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufPntReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[19] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|bufPntReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[20] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[21] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[22] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[23] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[24] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[25] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[26] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[27] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[28] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[29] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[30] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[31] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[32] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[33] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[34] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[35] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkCntReg[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[36] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[37] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[38] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[39] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[40] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[41] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[42] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[43] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[44] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[45] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[46] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[47] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[48] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[49] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[50] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[51] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkLimReg[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[52] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|clkReg" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[53] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|csReg" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[54] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|enReg" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[55] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[56] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[57] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[58] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[59] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[60] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[61] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[62] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[16]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[63] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[17]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[64] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[18]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[65] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[19]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[66] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[67] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[20]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[68] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[21]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[69] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[22]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[70] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[23]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[71] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[24]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[72] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[25]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[73] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[26]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[74] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[27]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[75] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[28]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[76] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[29]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[77] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[78] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[30]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[79] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[31]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[80] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[81] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[82] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[83] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[84] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[85] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[86] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Addr[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[87] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Cmd[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[88] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Cmd[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[89] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Cmd[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[90] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[91] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[92] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[93] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[94] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[95] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[96] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[97] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[16]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[98] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[17]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[99] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[18]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[100] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[19]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[101] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[102] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[20]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[103] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[21]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[104] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[22]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[105] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[23]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[106] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[24]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[107] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[25]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[108] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[26]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[109] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[27]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[110] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[28]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[111] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[29]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[112] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[113] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[30]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[114] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[31]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[115] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[116] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[117] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[118] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[119] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[120] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[121] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_M_Data[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[122] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[123] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[10]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[124] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[11]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[125] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[12]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[126] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[13]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[127] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[14]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[128] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[15]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[129] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[16]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[130] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[17]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[131] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[18]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[132] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[19]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[133] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[134] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[20]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[135] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[21]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[136] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[22]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[137] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[23]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[138] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[24]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[139] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[25]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[140] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[26]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[141] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[27]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[142] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[28]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[143] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[29]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[144] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[2]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[145] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[30]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[146] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[31]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[147] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[3]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[148] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[4]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[149] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[5]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[150] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[6]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[151] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[7]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[152] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[8]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[153] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Data[9]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[154] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Resp[0]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[155] -to "Patmos:comp|PatmosCore:core|InOut:iocomp|SDHostCtrl:SDHostCtrl|io_ocp_S_Resp[1]" -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[156] -to iSDHostCtrl_do -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[157] -to iSDHostCtrl_wp -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[158] -to oSDHostCtrl_clk -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[159] -to oSDHostCtrl_cs -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_data_in[160] -to oSDHostCtrl_di -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_RAM_BLOCK_TYPE=AUTO" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_DATA_BITS=161" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_BITS=161" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_BITS=161" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_NODE_INFO=805334528" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_POWER_UP_TRIGGER=0" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STORAGE_QUALIFIER_INVERSION_MASK_LENGTH=0" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_ATTRIBUTE_MEM_MODE=OFF" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STATE_FLOW_USE_GENERATED=0" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_STATE_BITS=11" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_BUFFER_FULL_STOP=1" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_CURRENT_RESOURCE_WIDTH=1" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_INCREMENTAL_ROUTING=1" -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[1] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[2] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[4] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[7] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[19] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[20] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[22] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[23] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[24] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[26] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[28] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[29] -to default|vcc -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_LEVEL=1" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_SAMPLE_DEPTH=16384" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_IN_ENABLED=0" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_TRIGGER_LEVEL_PIPELINE=1" -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[16] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[17] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[18] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[21] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[25] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[27] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[30] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[31] -to default|vcc -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_ADVANCED_TRIGGER_ENTITY=basic,1," -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_ENABLE_ADVANCED_TRIGGER=0" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_INVERSION_MASK=0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_INVERSION_MASK_LENGTH=511" -section_id default
+set_global_assignment -name SLD_NODE_PARAMETER_ASSIGNMENT "SLD_SEGMENT_SIZE=16384" -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[5] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[8] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[9] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[11] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[12] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[13] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[15] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[14] -to default|gnd -section_id default
+set_instance_assignment -name CONNECT_TO_SLD_NODE_ENTITY_PORT acq_clk -to "Patmos:comp|clk" -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[0] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[3] -to default|vcc -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[6] -to default|gnd -section_id default
+set_instance_assignment -name POST_FIT_CONNECT_TO_SLD_NODE_ENTITY_PORT crc[10] -to default|vcc -section_id default
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
+set_global_assignment -name SLD_FILE db/sd_signaltap_auto_stripped.stp

--- a/hardware/quartus/altde2-115-sd/patmos.sdc
+++ b/hardware/quartus/altde2-115-sd/patmos.sdc
@@ -1,0 +1,27 @@
+###########################################################################
+# SDC files for DE2-115 board
+###########################################################################
+
+# Clock in input pin (50 MHz)
+create_clock -period 20 [get_ports clk]
+
+# Create generated clocks based on PLLs
+derive_pll_clocks -use_tan_name
+
+derive_clock_uncertainty
+
+# ** Input/Output Delays
+
+# Use FPGA-centric constraints (general pins)
+# Tsu 5 ns
+set_max_delay -from [all_inputs] -to [all_registers] 5
+set_min_delay -from [all_inputs] -to [all_registers] 0
+# Tco 10 ns
+set_max_delay -from [all_registers] -to [all_outputs] 10
+set_min_delay -from [all_registers] -to [all_outputs] 0
+
+# Use FPGA-centric constraints (SRAM pins)
+# Tsu 3 ns
+set_max_delay -from [get_ports *RAM*] -to [get_registers {*}] 3
+# Tco 5.5 ns
+set_max_delay -from [get_registers *] -to [get_ports {*RAM*}] 5.5

--- a/hardware/src/io/SDHostCtrl.scala
+++ b/hardware/src/io/SDHostCtrl.scala
@@ -1,0 +1,177 @@
+/*
+   Copyright 2013 Technical University of Denmark, DTU Compute.
+   All rights reserved.
+
+   This file is part of the time-predictable VLIW processor Patmos.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+      1. Redistributions of source code must retain the above copyright notice,
+         this list of conditions and the following disclaimer.
+
+
+      2. Redistributions in binary form must reproduce the above copyright
+         notice, this list of conditions and the following disclaimer in the
+         documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+   NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   The views and conclusions contained in the software and documentation are
+   those of the authors and should not be interpreted as representing official
+   policies, either expressed or implied, of the copyright holder.
+ */
+
+/*
+ * SD host controller in SPI mode.
+ *
+ * Authors: Max Rishoej Pedersen (MaxRishoej@gmail.com)
+ *
+ */
+
+package io
+
+import Chisel._
+import Node._
+import ocp._
+
+object SDHostCtrl extends DeviceObject {
+  def init(params: Map[String, String]) = {
+  }
+
+  def create(params: Map[String, String]) : SDHostCtrl = {
+    Module(new SDHostCtrl())
+  }
+
+  trait Pins {
+    val sDHostCtrlPins = new Bundle() {
+      val sdClk = Bits(OUTPUT, 1);
+      val sdCs = Bits(OUTPUT, 1);
+      val sdDatOut = Bits(INPUT, 1); // Data Out on the card
+      val sdDatIn = Bits(OUTPUT, 1); // Data In on the card
+      val sdWp = Bits(INPUT, 1);
+    }
+  }
+}
+
+class SDHostCtrl() extends CoreDevice() {
+  override val io = new CoreDeviceIO() with SDHostCtrl.Pins
+
+  // Internals
+  val enReg = Reg(Bool(false)) // Is the controller enabled?
+  val bufPntReg = Reg(UInt(0, 4)) // Counts the bit being transmitted.
+                                  // Must be large enough to contain buffer size.
+
+  // Clock
+  val DEFAULTCLKDIV = 100 // 80MHz Patmos -> 400kHz SCLK
+  val clkDivReg = Reg(UInt(DEFAULTCLKDIV, 16))
+  val clkCntReg = Reg(UInt(0, 16)) // Could be smaller
+  val clkReg = Reg(Bool(true))
+
+  // Buffer
+  val bufOutReg = Reg(Bits(width = 8))
+  val bufInReg = Reg(Bits(width = 8))
+
+  // Settings register
+  val csReg = Reg(Bool(false)) // CS pin
+
+  // OCP
+  val ocpDataReg = Reg(Bits(width = 32))
+  val ocpRespReg = Reg(Bits(width = 2))
+  ocpRespReg := OcpResp.NULL
+
+  // Write to registers
+  when(io.ocp.M.Cmd === OcpCmd.WR) {
+    ocpDataReg := io.ocp.M.Data
+    ocpRespReg := OcpResp.DVA
+
+    switch(io.ocp.M.Addr(5,2)) {
+      // Data is written
+      is(Bits("b0000")) {
+        bufOutReg := io.ocp.M.Data
+        bufInReg := UInt(0)
+
+        // Trigger transaction
+        enReg := Bool(true)
+        bufPntReg := UInt(8)
+        clkCntReg := clkDivReg
+      }
+
+      // Write to CS register
+      is(Bits("b0001")) {
+        csReg := io.ocp.M.Data =/= UInt(0)
+      }
+
+      // Write to CKLDIV register
+      is(Bits("b0011")) {
+        clkDivReg := UInt(io.ocp.M.Data)
+      }
+    }
+  }
+
+  // Read from registers
+  when(io.ocp.M.Cmd === OcpCmd.RD) {
+    ocpRespReg := OcpResp.DVA
+
+    switch(io.ocp.M.Addr(5,2)) {
+      // Reading data. Doesn't trigger enable.
+      is(Bits("b0000")) {
+        ocpDataReg := bufInReg
+      }
+
+      // Allow reading enReg
+      is(Bits("b0010")) {
+        ocpDataReg := enReg
+      }
+    }
+  }
+
+  // Connections to master
+  io.ocp.S.Resp := ocpRespReg
+  io.ocp.S.Data := ocpDataReg
+
+  // Connections to pins
+  val bufIdx = bufPntReg - UInt(1) // For convenience
+
+  when(enReg === Bool(true)) {
+    when (clkCntReg === UInt(1)) {
+      clkCntReg := clkDivReg
+      clkReg := ~clkReg
+
+      when(clkReg === Bool(true)) { // Falling edge -> Sample
+        bufInReg(bufIdx) := io.sDHostCtrlPins.sdDatOut
+
+        // Count clock cycles
+        when (bufPntReg === UInt(1)) {
+          enReg := Bool(false) // Transaction done
+        }
+        .otherwise {
+          bufPntReg := bufPntReg - UInt(1)
+        }
+      }
+    }
+    .otherwise {
+      clkCntReg := clkCntReg - UInt(1)
+    }
+
+    io.sDHostCtrlPins.sdClk := clkReg
+  }
+  .otherwise { // Not enabled
+    io.sDHostCtrlPins.sdClk := Bool(false) 
+    clkReg := Bool(false) // As to begin with a rising edge
+  }
+
+  io.sDHostCtrlPins.sdDatIn := bufOutReg(bufIdx)
+
+  // Always
+  io.sDHostCtrlPins.sdCs := csReg
+} 

--- a/hardware/vhdl/patmos_de2-115-sd.vhdl
+++ b/hardware/vhdl/patmos_de2-115-sd.vhdl
@@ -1,0 +1,162 @@
+--
+-- Copyright: 2013, Technical University of Denmark, DTU Compute
+-- Author: Martin Schoeberl (martin@jopdesign.com)
+--         Rasmus Bo Soerensen (rasmus@rbscloud.dk)
+--         Max Rishoej (maxrishoej@gmail.com)
+-- License: Simplified BSD License
+--
+
+-- VHDL top level for Patmos in Chisel on Altera de2-115 board with SD card
+-- port in SPI mode
+--
+-- Includes some 'magic' VHDL code to generate a reset after FPGA configuration.
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity patmos_top is
+	port(
+		clk : in  std_logic;
+		oLedsPins_led : out std_logic_vector(8 downto 0);
+		iKeysPins_key : in std_logic_vector(3 downto 0);
+		oUartPins_txd : out std_logic;
+		iUartPins_rxd : in  std_logic;
+        oSRAM_A : out std_logic_vector(19 downto 0);
+        SRAM_DQ : inout std_logic_vector(15 downto 0);
+        oSRAM_CE_N : out std_logic;
+        oSRAM_OE_N : out std_logic;
+        oSRAM_WE_N : out std_logic;
+        oSRAM_LB_N : out std_logic;
+        oSRAM_UB_N : out std_logic;
+    oSDHostCtrl_clk : out std_logic;
+    oSDHostCtrl_cs  : out std_logic;
+    oSDHostCtrl_di  : out std_logic;
+    iSDHostCtrl_do  : in std_logic;
+    iSDHostCtrl_wp  : in std_logic
+    
+	);
+end entity patmos_top;
+
+architecture rtl of patmos_top is
+	component Patmos is
+		port(
+			clk             : in  std_logic;
+			reset           : in  std_logic;
+
+			io_comConf_M_Cmd        : out std_logic_vector(2 downto 0);
+			io_comConf_M_Addr       : out std_logic_vector(31 downto 0);
+			io_comConf_M_Data       : out std_logic_vector(31 downto 0);
+			io_comConf_M_ByteEn     : out std_logic_vector(3 downto 0);
+			io_comConf_M_RespAccept : out std_logic;
+			io_comConf_S_Resp       : in std_logic_vector(1 downto 0);
+			io_comConf_S_Data       : in std_logic_vector(31 downto 0);
+			io_comConf_S_CmdAccept  : in std_logic;
+
+			io_comSpm_M_Cmd         : out std_logic_vector(2 downto 0);
+			io_comSpm_M_Addr        : out std_logic_vector(31 downto 0);
+			io_comSpm_M_Data        : out std_logic_vector(31 downto 0);
+			io_comSpm_M_ByteEn      : out std_logic_vector(3 downto 0);
+			io_comSpm_S_Resp        : in std_logic_vector(1 downto 0);
+			io_comSpm_S_Data        : in std_logic_vector(31 downto 0);
+
+			io_cpuInfoPins_id   : in  std_logic_vector(31 downto 0);
+			io_cpuInfoPins_cnt  : in  std_logic_vector(31 downto 0);
+			io_ledsPins_led : out std_logic_vector(8 downto 0);
+			io_keysPins_key : in  std_logic_vector(3 downto 0);
+			io_uartPins_tx  : out std_logic;
+			io_uartPins_rx  : in  std_logic;
+
+            io_sramCtrlPins_ramOut_addr : out std_logic_vector(19 downto 0);
+            io_sramCtrlPins_ramOut_doutEna : out std_logic;
+            io_sramCtrlPins_ramIn_din : in std_logic_vector(15 downto 0);
+            io_sramCtrlPins_ramOut_dout : out std_logic_vector(15 downto 0);
+            io_sramCtrlPins_ramOut_nce : out std_logic;
+            io_sramCtrlPins_ramOut_noe : out std_logic;
+            io_sramCtrlPins_ramOut_nwe : out std_logic;
+            io_sramCtrlPins_ramOut_nlb : out std_logic;
+            io_sramCtrlPins_ramOut_nub : out std_logic;
+
+     io_sDHostCtrlPins_sdClk    : out std_logic;
+     io_sDHostCtrlPins_sdCs     : out std_logic;
+     io_sDHostCtrlPins_sdDatIn  : out std_logic;
+     io_sDHostCtrlPins_sdDatOut : in std_logic;
+     io_sDHostCtrlPins_sdWp     : in std_logic
+
+		);
+	end component;
+
+	-- DE2-70: 50 MHz clock => 80 MHz
+	-- BeMicro: 16 MHz clock => 25.6 MHz
+	constant pll_infreq : real    := 50.0;
+	constant pll_mult   : natural := 8;
+	constant pll_div    : natural := 5;
+
+	signal clk_int : std_logic;
+
+	-- for generation of internal reset
+	signal int_res            : std_logic;
+	signal res_reg1, res_reg2 : std_logic;
+	signal res_cnt            : unsigned(2 downto 0) := "000"; -- for the simulation
+
+    -- sram signals for tristate inout
+    signal sram_out_dout_ena : std_logic;
+    signal sram_out_dout : std_logic_vector(15 downto 0);
+
+	attribute altera_attribute : string;
+	attribute altera_attribute of res_cnt : signal is "POWER_UP_LEVEL=LOW";
+
+begin
+	pll_inst : entity work.pll generic map(
+			input_freq  => pll_infreq,
+			multiply_by => pll_mult,
+			divide_by   => pll_div
+		)
+		port map(
+			inclk0 => clk,
+			c0     => clk_int
+		);
+	-- we use a PLL
+	-- clk_int <= clk;
+
+	--
+	--	internal reset generation
+	--	should include the PLL lock signal
+	--
+	process(clk_int)
+	begin
+		if rising_edge(clk_int) then
+			if (res_cnt /= "111") then
+				res_cnt <= res_cnt + 1;
+			end if;
+			res_reg1 <= not res_cnt(0) or not res_cnt(1) or not res_cnt(2);
+			res_reg2 <= res_reg1;
+			int_res  <= res_reg2;
+		end if;
+	end process;
+
+
+    -- tristate output to ssram
+    process(sram_out_dout_ena, sram_out_dout)
+    begin
+      if sram_out_dout_ena='1' then
+        SRAM_DQ <= sram_out_dout;
+      else
+        SRAM_DQ <= (others => 'Z');
+      end if;
+    end process;
+
+    comp : Patmos port map(clk_int, int_res,
+           open, open, open, open, open,
+           (others => '0'), (others => '0'), '0',
+           open, open, open, open,
+           (others => '0'), (others => '0'),
+           X"00000000", X"00000001",
+           oLedsPins_led,
+           iKeysPins_key,
+           oUartPins_txd, iUartPins_rxd,
+           oSRAM_A, sram_out_dout_ena, SRAM_DQ, sram_out_dout, oSRAM_CE_N, oSRAM_OE_N, oSRAM_WE_N, oSRAM_LB_N, oSRAM_UB_N,
+           oSDHostCtrl_clk, oSDHostCtrl_cs, oSDHostCtrl_di, iSDHostCtrl_do, iSDHostCtrl_wp);
+
+end architecture rtl;


### PR DESCRIPTION
This implements file and directory access for a FAT32 formatted SD card connected to an Altera DE2-115.
This is done in the separate configuration "patmos_de2-115-sd".

It provides a host controller component in Chisel, a driver for the host controller and a file system module.

The host controller utilizes the SPI mode of SD cards and as a result is rather slow (~ 0.2 MB/s).
It should be easily replaceable however, without requiring changes to the file system module.