### PR TITLE
pasim: Data hazard predicate check

### DIFF
--- a/simulator/src/simulation-core.cc
+++ b/simulator/src/simulation-core.cc
@@ -379,9 +379,14 @@ namespace patmos
             if (dst != r0) {
               for (unsigned int j = 0; j < NUM_SLOTS; j++) {
                 const instruction_t *ex_instr = Pipeline[SEX][j].I;
-
-                if (ex_instr && (ex_instr->get_src1_reg(Pipeline[SEX][j]) == dst ||
-                                ex_instr->get_src2_reg(Pipeline[SEX][j]) == dst))
+                if (  ex_instr && 
+                      // Either operand is the same as the source of the previous load instruction
+                      (ex_instr->get_src1_reg(Pipeline[SEX][j]) == dst ||
+                      ex_instr->get_src2_reg(Pipeline[SEX][j]) == dst) &&
+                      // The instruction is being executed (predicate is true)
+                      PRR.get(Pipeline[SEX][j].Pred).get() &&
+                      // The previous load instruction is being executed
+                      PRR.get(Pipeline[SMW][0].Pred).get())
                 {
                   simulation_exception_t::illegal("Use of load result without delay slot!");
                 }

--- a/simulator/tests/CMakeLists.txt
+++ b/simulator/tests/CMakeLists.txt
@@ -145,6 +145,8 @@ Errors : 0")
 test_asm(50 "Emitted: 216 bytes
 Errors : 0")
 
+test_asm(51 "Emitted: 72 bytes
+Errors : 0")
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # SIMULATOR TESTS
@@ -273,7 +275,6 @@ test_sim_lp(42 "   Blocks Not Spilled  :          6           6")
 
 test_sim(43 "r0 : 00000000   r1 : 00000001   r2 : 00000005")
 
-
 test_sim(44 "PRR: 00000011.*
 .*r1 : 00000008   r2 : 0000000c")
 
@@ -290,3 +291,4 @@ test_sim_scba(50 "Align .*spill.*:          2           2
    Align .*fill.*:          0           0
    Align .*free.*:          4           4")
 
+test_sim(51 "r1 : 00400000   r2 : 003ffffb   r3 : 00000005")

--- a/simulator/tests/test51.s
+++ b/simulator/tests/test51.s
@@ -1,0 +1,20 @@
+#
+# Tests that if an instruction's predicate is false, no data hazard error is thrown
+# if an operand register of the instruction is being loaded by the previous instruction.
+# Expected Result: r1 = 0x00400000 & r2 = 0x003ffffb & r3 = 5
+#
+                .word   72;
+        (p0)    lwc     r1 = [r0 + x];
+        (!p0)   add     r1 = r1 , 5;
+        (p0)    sub     r2 = r1 , 5;
+                add     r3 = r0, 0;
+        (!p0)   lwc     r3 = [r0 + x];
+        (p0)    add     r3 = r3 , 5;
+        (!p0)   sub     r4 = r3 , 5;
+                halt;
+        nop;
+        nop;
+        nop;
+x:	
+        nop;
+	


### PR DESCRIPTION
`pasim` now takes the runtime value of predicates into account before issuing a data hazard error.
Fixes #40.