### PR TITLE
Specified emulator SBT version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 config.mk*
 *~
-hardware/project
+hardware/project/target
 hardware/target
 hardware/build
 hardware/generated

--- a/hardware/project/build.properties
+++ b/hardware/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.6


### PR DESCRIPTION
This solves an issue where the emulator fails to compile if the installed sbt version is > 1.3.
Without specifying an sbt version in `hardware/project/build.properties`, sbt will use the installed version to build the emulator with (the currently newest version is 1.3.3).
For some reason, the emulator cannot compile properly if sbt > 1.3 is used, throwing the following error:
```
[init] error: error while loading Object, Missing dependency 'object scala in compiler mirror', required by /home/user/.sbt/0.13/java9-rt-ext-ubuntu_11_0_4/rt.jar(java/lang/Object.class)
```

Both Michael and I have this error, and it was solved by manually setting the sbt version to 1.2.6 in `hardware/project/build.properties`. 
This PR ensures the same version of sbt is always used (v1.2.6), ensuring the emulator can compile on up-to-date installations.
This also ensures new users of Patmos can successfully execute the `./misc/build.sh` script.