### PR TITLE
Eliminate the use of 'patmos-ar'

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -104,7 +104,7 @@ $(NOCINIT):
 libnoc: $(LIBNOC)
 $(BUILDDIR)/libnoc/noc.o: libnoc/noc.h libnoc/coreset.h
 $(LIBNOC): $(BUILDDIR)/libnoc/noc.o
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 # library for message passing
 .PHONY: libmp
@@ -116,20 +116,20 @@ $(BUILDDIR)/libmp/sampling.o: libmp/mp.h libmp/mp_internal.h libnoc/noc.h
 $(BUILDDIR)/libmp/lock.o: libmp/mp.h libmp/mp_internal.h libnoc/noc.h
 $(BUILDDIR)/libmp/collective.o: libmp/mp.h libmp/mp_internal.h libnoc/noc.h libnoc/coreset.h
 $(LIBMP): $(BUILDDIR)/libmp/utils.o $(BUILDDIR)/libmp/mp.o $(BUILDDIR)/libmp/queuing.o $(BUILDDIR)/libmp/sampling.o $(BUILDDIR)/libmp/lock.o
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 # library for corethreads
 .PHONY: libcorethread
 libcorethread: $(LIBCORETHREAD)
 $(BUILDDIR)/libcorethread/corethread.o: libcorethread/corethread.h
 $(LIBCORETHREAD): $(BUILDDIR)/libcorethread/corethread.o
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 # library for ethernet
 .PHONY: libeth
 libeth: $(LIBETH)
 $(LIBETH): $(patsubst ethlib/%.c,$(BUILDDIR)/ethlib/%.o,$(wildcard ethlib/*.c))
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 #library for audio
 .PHONY: libaudio
@@ -137,16 +137,16 @@ libaudio: $(LIBAUDIO)
 $(BUILDDIR)/libaudio/dsp_algorithms.o: libaudio/dsp_algorithms.h
 $(BUILDDIR)/libaudio/audio.o: libaudio/audio.h libaudio/audioinit.h libaudio/latencyinit.h
 $(LIBAUDIO): $(BUILDDIR)/libaudio/dsp_algorithms.o $(BUILDDIR)/libaudio/audio.o
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 # library for parsing ELF files
 .PHONY: libelf
 libelf: $(LIBELF)
 $(LIBELF): $(patsubst libelf/%.c,$(BUILDDIR)/libelf/%.o,$(wildcard libelf/*.c))
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 # library for using SD card
 .PHONY: libsd
 libsd: $(LIBSD)
 $(LIBSD): $(patsubst libsd/%.c,$(BUILDDIR)/libsd/%.o,$(wildcard libsd/*.c))
-	patmos-ar r $@ $^
+	ar r $@ $^

--- a/c/apps/aion/Makefile
+++ b/c/apps/aion/Makefile
@@ -14,7 +14,7 @@ CFLAGS?=-target patmos-unknown-unknown-elf -O2 \
 .PHONY: libeth
 libeth: $(LIBETH)
 $(LIBETH): $(patsubst ethlib/%.c,$(BUILDDIR)/ethlib/%.o,$(wildcard ethlib/*.c))
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 # WCET analysis
 

--- a/c/apps/poorman-tte/Makefile
+++ b/c/apps/poorman-tte/Makefile
@@ -25,7 +25,7 @@ wcet:
 .PHONY: libeth
 libeth: $(LIBETH)
 $(LIBETH): $(patsubst ethlib/%.c,$(BUILDDIR)/ethlib/%.o,$(wildcard ethlib/*.c))
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 ttepwm-comp:
 	patmos-clang -O2 -D $(ROLE) $(CFLAGS) $(LIBETH)/*.c $(LIBETH)/*.h ttepwm.c ttepwm.h -o ttepwm_$(ROLE).elf

--- a/c/apps/tte-flight/Makefile
+++ b/c/apps/tte-flight/Makefile
@@ -18,7 +18,7 @@ wcet-server:
 .PHONY: libeth
 libeth: $(LIBETH)
 $(LIBETH): $(patsubst ethlib/%.c,$(BUILDDIR)/ethlib/%.o,$(wildcard ethlib/*.c))
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 flight_info_server:
 	touch flight_info_server.c

--- a/c/apps/tte-node/Makefile
+++ b/c/apps/tte-node/Makefile
@@ -20,7 +20,7 @@ wcet:
 .PHONY: libeth
 libeth: $(LIBETH)
 $(LIBETH): $(patsubst ethlib/%.c,$(BUILDDIR)/ethlib/%.o,$(wildcard ethlib/*.c))
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 tte_demo:
 	patmos-clang -O2 $(CFLAGS) $(LIBETH)/*.c tte_demo.c -o tte_demo.elf

--- a/c/apps/ttscheduling/Makefile
+++ b/c/apps/ttscheduling/Makefile
@@ -18,14 +18,14 @@ CFLAGS?=-target patmos-unknown-unknown-elf -O2 \
 .PHONY: libeth
 libeth: $(LIBETH)
 $(LIBETH): $(patsubst ethlib/%.c,$(BUILDDIR)/ethlib/%.o,$(wildcard ethlib/*.c))
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 # library for corethreads
 .PHONY: libcorethread
 libcorethread: $(LIBCORETHREAD)
 $(BUILDDIR)/libcorethread/corethread.o: libcorethread/corethread.h
 $(LIBCORETHREAD): $(BUILDDIR)/libcorethread/corethread.o
-	patmos-ar r $@ $^
+	ar r $@ $^
 
 # WCET analysis
 


### PR DESCRIPTION
Removes all uses of `patmos-ar` and replaces it with `ar` (binutils), which should be already available on the machine.

`patmos-ar` is produced by the `patmos-gold` repository.
The handbook says `patmos-ar` has some special support for bitcode archives, but my understanding is that it is otherwise identical. Therefore, I'm beginning with simply removing use of `patmos-ar` where this special support doesn't seem needed.

Caveat: 
Since I don't know how the apps that use `patmos-ar` should behave, I cannot guarantee that they still work as expected. I have no idea how to test them (or simply don't have the hardware to) and the nightly test also doesn't use them. Therefore, please highlight this PR to any stakeholders before merging.

This is part of an effort to simplify the setup of the Patmos tool chain and as such remove the need for and use of `patmos-ar` across all T-CREST repositories.

