### PR TITLE
ROM Update

### DIFF
--- a/hardware/quartus/altde2-115-sdram/patmos.qsf
+++ b/hardware/quartus/altde2-115-sdram/patmos.qsf
@@ -91,6 +91,8 @@ set_global_assignment -name VHDL_FILE ../../../../sdram/vhdl/sdr_dram.vhd
 set_global_assignment -name VHDL_FILE ../../../../sdram/vhdl/sc_sdram_top_de2_115.vhd
 set_global_assignment -name VHDL_FILE "../../vhdl/patmos_de2-115-sdram.vhdl"
 set_global_assignment -name VERILOG_FILE ../../build/Patmos.v
+set_global_assignment -name VERILOG_FILE ../../build/BlackBoxRom.v
+
 set_location_assignment PIN_U2 -to dram0_LDQM
 set_location_assignment PIN_W4 -to dram0_UDQM
 set_location_assignment PIN_K8 -to dram1_LDQM

--- a/hardware/quartus/altde2-115/patmos.qsf
+++ b/hardware/quartus/altde2-115/patmos.qsf
@@ -122,6 +122,7 @@ set_global_assignment -name DEVICE_FILTER_PACKAGE FBGA
 set_global_assignment -name VHDL_FILE "../../vhdl/patmos_de2-115.vhdl"
 set_global_assignment -name VHDL_FILE ../../vhdl/altera/cyc2_pll.vhd
 set_global_assignment -name VERILOG_FILE ../../build/Patmos.v
+set_global_assignment -name VERILOG_FILE ../../build/BlackBoxRom.v
 
 set_global_assignment -name VHDL_FILE "../../../../argo/src/ocp/ocp_config.vhd"
 set_global_assignment -name VHDL_FILE "../../../../argo/src/ocp/ocp.vhd"

--- a/hardware/quartus/altde2-all/patmos.qsf
+++ b/hardware/quartus/altde2-all/patmos.qsf
@@ -339,6 +339,7 @@ set_global_assignment -name VHDL_FILE ../../vhdl/fpu_double/fpu_round.vhd
 set_global_assignment -name VHDL_FILE ../../vhdl/fpu_double/fpu_exceptions.vhd
 set_global_assignment -name VHDL_FILE ../../vhdl/fpu_double/fpu_double.vhd
 set_global_assignment -name VERILOG_FILE ../../build/Patmos.v
+set_global_assignment -name VERILOG_FILE ../../build/BlackBoxRom.v
 set_global_assignment -name VHDL_FILE "../../vhdl/patmos_de2-all.vhdl"
 
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to oSRAM_A[0]

--- a/hardware/quartus/de10-nano-drone/patmos.qsf
+++ b/hardware/quartus/de10-nano-drone/patmos.qsf
@@ -97,6 +97,7 @@ set_global_assignment -name VHDL_FILE ../../vhdl/other/Actuators.vhd
 set_global_assignment -name VHDL_FILE "../../vhdl/patmos_de10-nano-drone.vhdl"
 set_global_assignment -name VERILOG_FILE ../../ext/aau/imu_mpu.v
 set_global_assignment -name VERILOG_FILE ../../build/Patmos.v
+set_global_assignment -name VERILOG_FILE ../../build/BlackBoxRom.v
 
 
 

--- a/hardware/quartus/de10-nano/patmos.qsf
+++ b/hardware/quartus/de10-nano/patmos.qsf
@@ -88,6 +88,7 @@ set_global_assignment -name VHDL_FILE ../../vhdl/other/I2Ccontroller.vhd
 set_global_assignment -name VHDL_FILE "../../vhdl/patmos_de10-nano.vhdl"
 set_global_assignment -name VERILOG_FILE ../../ext/aau/imu_mpu.v
 set_global_assignment -name VERILOG_FILE ../../build/Patmos.v
+set_global_assignment -name VERILOG_FILE ../../build/BlackBoxRom.v
 set_global_assignment -name SIGNALTAP_FILE stp1.stp
 set_location_assignment PIN_AG14 -to pwm_measurment_input[0]
 set_location_assignment PIN_AE6 -to pwm_measurment_input[1]

--- a/hardware/src/main/scala/util/BlackBoxRom.scala
+++ b/hardware/src/main/scala/util/BlackBoxRom.scala
@@ -1,0 +1,78 @@
+/*
+ * Black Box ROM to fix Chisel 2 to Chisel 3 migration issue in patmos Fetch stage
+ * based on https://www.chisel-lang.org/chisel3/docs/explanations/blackboxes.html
+ *
+ * Author: Bosse Bandowski (bosse.bandowski@outlook.com)
+ *
+ */
+
+package util
+
+
+import chisel3._
+import chisel3.util.HasBlackBoxInline
+import patmos.Constants._
+
+class BlackBoxRom(romContents : (Array[BigInt], Array[BigInt]), addrWidth : Int) extends BlackBox with HasBlackBoxInline {
+    
+    val io = IO(new Bundle {
+        val addressEven = Input(UInt(addrWidth.W))
+        val addressOdd = Input(UInt(addrWidth.W))
+        val instructionEven = Output(UInt(INSTR_WIDTH.W))
+        val instructionOdd = Output(UInt(INSTR_WIDTH.W))
+    })
+
+    val romLinePatternEven = "\t|\t%d: instructionEven = %d'h%x;\n"
+    val romLinePatternOdd = "\t|\t%d: instructionOdd = %d'h%x;\n"
+
+
+    val HEADER =    """module %s
+        |#(
+        |    parameter  addrWidth = %d,
+        |               instrWidth = %d
+        |)
+        |(
+        |    input wire [addrWidth-1:0] addressEven,
+        |    input wire [addrWidth-1:0] addressOdd,
+        |    output reg [instrWidth-1:0] instructionEven,
+        |    output reg [instrWidth-1:0] instructionOdd
+        |);
+        """.format(name, addrWidth, INSTR_WIDTH)
+
+    val FOOTER_EVEN =    """
+        |    default: begin
+        |        instructionEven = %d'bx;
+        |        `ifndef SYNTHESIS
+        |            // synthesis translate_off
+        |            instructionEven = {1{$random}};
+        |            // synthesis translate_on
+        |        `endif
+        |    end
+        |endcase
+        """.format(INSTR_WIDTH)
+
+    val FOOTER_ODD =    """
+        |    default: begin
+        |        instructionOdd = %d'bx;
+        |        `ifndef SYNTHESIS
+        |            // synthesis translate_off
+        |            instructionOdd = {1{$random}};
+        |            // synthesis translate_on
+        |        `endif
+        |    end
+        |endcase
+        """.format(INSTR_WIDTH)
+
+    val FOOTER_MODULE = "\n|endmodule"
+
+
+    var BODY_EVEN = "\n|always @(*) case (addressEven)\n"
+    var BODY_ODD = "\n|always @(*) case (addressOdd)\n"
+
+    for (id <- 0 to romContents._1.length - 1) {
+        BODY_EVEN = BODY_EVEN + romLinePatternEven.format(id, INSTR_WIDTH, romContents._1(id))
+        BODY_ODD = BODY_ODD + romLinePatternOdd.format(id, INSTR_WIDTH, romContents._2(id))
+    }
+
+    setInline(name + ".v", (HEADER + BODY_EVEN + FOOTER_EVEN + BODY_ODD + FOOTER_ODD + FOOTER_MODULE).stripMargin)
+}


### PR DESCRIPTION
The migration from chisel2 to chisel3 was causing an inefficient ROM implementation with timing issues.
This is now fixed and the patch includes the following changes:

- a new read function of the BOOTAPP file that returns a scala Array tuple instead of a chisel Vec
- a new BlackBoxRom class that parses the Array tuple into valid Verilog code and wraps it in a black box
- minor updates to the Fetch stage of patmos to match the changes
- updates to all quartus project files to include a new file BlackBoxRom.v that is created during `make gen`

Tested with blinking in emulator, and the bootloader on an FPGA