### PR TITLE
Add Skywater SRAM model

### DIFF
--- a/hardware/quartus/altde2-115/patmos.qsf
+++ b/hardware/quartus/altde2-115/patmos.qsf
@@ -123,6 +123,7 @@ set_global_assignment -name VHDL_FILE "../../vhdl/patmos_de2-115.vhdl"
 set_global_assignment -name VHDL_FILE ../../vhdl/altera/cyc2_pll.vhd
 set_global_assignment -name VERILOG_FILE ../../build/Patmos.v
 set_global_assignment -name VERILOG_FILE ../../build/BlackBoxRom.v
+set_global_assignment -name VERILOG_FILE ../../build/sky130_sram_1kbyte_1rw1r_8x1024_8.v
 
 set_global_assignment -name VHDL_FILE "../../../../argo/src/ocp/ocp_config.vhd"
 set_global_assignment -name VHDL_FILE "../../../../argo/src/ocp/ocp.vhd"

--- a/hardware/src/main/scala/util/SRAM.scala
+++ b/hardware/src/main/scala/util/SRAM.scala
@@ -1,0 +1,116 @@
+package util
+
+import chisel3._
+import chisel3.util.{HasBlackBoxPath, UIntToOH}
+import SRAM.{SeqToVec, extractBytes}
+
+
+class SRAM(size: Int, width: Int) extends Module {
+
+  val addrWidth = log2Up(size)
+
+  val io = IO(new Bundle {
+    val rdAddr = Input(UInt(addrWidth.W))
+    val rdData = Output(UInt(width.W))
+    val wrAddr = Input(UInt(addrWidth.W))
+    val wrEna  = Input(Bool())
+    val wrData = Input(UInt(width.W))
+  })
+
+  // number of banks needed to achieve the requested depth
+  val numberOfBanks = scala.math.ceil(size / 1024.0).toInt
+
+  io.rdData := extractBytes(io.wrData) // split write data into bytes
+    .map { wrByte => // for each byte column, write and return read wire
+
+    if(addrWidth <= 10) { // only one bank is needed to achieve depth
+
+      val bank = SRAMBlackBox(this.clock)
+      bank.write(io.wrEna)(io.wrAddr, wrByte)
+      bank.read(io.rdAddr) // return read wire
+
+    } else { // multiple banks are needed to achieve depth
+
+      val banks = Seq.fill(numberOfBanks)(SRAMBlackBox(this.clock))
+
+      val bankSelectors = // create one hot bank selection signal
+        UIntToOH(io.rdAddr(addrWidth - 1, 10))
+          .asBools
+          .take(numberOfBanks)
+
+      // reduction function to select the correct read data from the banks
+      def select(left: (Bool, UInt), right: (Bool, UInt)): (Bool, UInt) =
+        Mux(left._1, left._1, right._1) -> Mux(left._1, left._2, right._2)
+
+      // read access
+      val (_, rdByte) = banks
+        .zip(bankSelectors)
+        .map { case (bank, sel) => sel -> bank.read(io.rdAddr(10, 0)) } // create selector and read value pairs
+        .reduce(select) // select the ONE read value with an asserted selector
+
+      banks
+        .zip(bankSelectors)
+        .foreach { case (bank, sel) => bank.write(io.wrEna && sel)(io.wrAddr(10, 0), wrByte) } // write to bank when wrEna and the bank selector are asserted
+
+      rdByte // return read wire
+    }
+
+  }.toVec.reduceTree(_ ## _) // concatenate all byte read values
+
+}
+
+object SRAM {
+
+  // allow for method call conversion to a chisel vec
+  implicit class SeqToVec[T <: Data](seq: Seq[T]) { def toVec: Vec[T] = VecInit(seq) }
+
+  // create an array of bytes from an arbitrary UInt
+  def extractBytes(num: UInt): Seq[UInt] = {
+    val numBytes = scala.math.ceil(num.getWidth / 8.0).toInt
+    num(num.getWidth-1, (numBytes-1) * 8).asTypeOf(UInt(8.W)) +: Seq.tabulate(numBytes-1)(_ * 8).map(i => num(i+7,i))
+  }
+}
+
+object SRAMBlackBox {
+  def apply(clock: Clock): sky130_sram_1kbyte_1rw1r_8x1024_8 = {
+    val sram = Module(new sky130_sram_1kbyte_1rw1r_8x1024_8)
+    sram.io.clk0 := clock
+    sram.io.clk1 := clock
+    sram.io.csb0 := 0.B // always selected
+    sram.io.csb1 := 0.B // always selected
+    sram.io.wmask0 := 1.U // the 1 byte write value is always enabled
+    sram
+  }
+}
+
+class sky130_sram_1kbyte_1rw1r_8x1024_8 extends BlackBox with HasBlackBoxPath {
+
+  val io = IO(new Bundle {
+    val clk0 = Input(Clock()) // rw port clock
+    val csb0 = Input(Bool()) // rw port active low chip select
+    val web0 = Input(Bool()) // wr port active low write control
+    val wmask0 = Input(UInt(1.W)) // write mask
+    val addr0 = Input(UInt(10.W)) // rw port address
+    val din0 = Input(UInt(8.W)) // rw port write data
+    val dout0 = Output(UInt(8.W)) // rw port read data
+    val clk1 = Input(Clock()) // r port clock
+    val csb1 = Input(Bool()) // r port active low chip select
+    val addr1 = Input(UInt(10.W)) // r port address
+    val dout1 = Output(UInt(8.W)) // r port read data
+  })
+  addPath("verilog/sky130_sram_1kbyte_1rw1r_8x1024_8.v")
+
+  // connect signals for a read
+  def read(index: UInt): UInt = {
+    io.addr1 := index
+    io.dout0
+  }
+
+  // connect signals for a write
+  def write(en: Bool)(index: UInt, data: UInt): Unit = {
+    io.web0 := !en
+    io.addr0 := index
+    io.din0 := data
+  }
+
+}

--- a/hardware/verilog/sky130_sram_1kbyte_1rw1r_8x1024_8.v
+++ b/hardware/verilog/sky130_sram_1kbyte_1rw1r_8x1024_8.v
@@ -1,0 +1,108 @@
+// OpenRAM SRAM model
+// Words: 1024
+// Word size: 8
+// Write size: 8
+
+module sky130_sram_1kbyte_1rw1r_8x1024_8(
+`ifdef USE_POWER_PINS
+    vccd1,
+    vssd1,
+`endif
+// Port 0: RW
+    clk0,csb0,web0,wmask0,addr0,din0,dout0,
+// Port 1: R
+    clk1,csb1,addr1,dout1
+  );
+
+  parameter NUM_WMASKS = 1 ;
+  parameter DATA_WIDTH = 8 ;
+  parameter ADDR_WIDTH = 10 ;
+  parameter RAM_DEPTH = 1 << ADDR_WIDTH;
+  // FIXME: This delay is arbitrary.
+  parameter DELAY = 1 ;
+  parameter VERBOSE = 1 ; //Set to 0 to only display warnings
+  parameter T_HOLD = 1 ; //Delay to hold dout value after posedge. Value is arbitrary
+
+`ifdef USE_POWER_PINS
+    inout vccd1;
+    inout vssd1;
+`endif
+  input  clk0; // clock
+  input   csb0; // active low chip select
+  input  web0; // active low write control
+  input [NUM_WMASKS-1:0]   wmask0; // write mask
+  input [ADDR_WIDTH-1:0]  addr0;
+  input [DATA_WIDTH-1:0]  din0;
+  output [DATA_WIDTH-1:0] dout0;
+  input  clk1; // clock
+  input   csb1; // active low chip select
+  input [ADDR_WIDTH-1:0]  addr1;
+  output [DATA_WIDTH-1:0] dout1;
+
+  reg  csb0_reg;
+  reg  web0_reg;
+  reg [NUM_WMASKS-1:0]   wmask0_reg;
+  reg [ADDR_WIDTH-1:0]  addr0_reg;
+  reg [DATA_WIDTH-1:0]  din0_reg;
+  reg [DATA_WIDTH-1:0]  dout0;
+
+  // All inputs are registers
+  always @(posedge clk0)
+  begin
+    csb0_reg = csb0;
+    web0_reg = web0;
+    wmask0_reg = wmask0;
+    addr0_reg = addr0;
+    din0_reg = din0;
+    #(T_HOLD) dout0 = 8'bx;
+    if ( !csb0_reg && web0_reg && VERBOSE )
+      $display($time," Reading %m addr0=%b dout0=%b",addr0_reg,mem[addr0_reg]);
+    if ( !csb0_reg && !web0_reg && VERBOSE )
+      $display($time," Writing %m addr0=%b din0=%b wmask0=%b",addr0_reg,din0_reg,wmask0_reg);
+  end
+
+  reg  csb1_reg;
+  reg [ADDR_WIDTH-1:0]  addr1_reg;
+  reg [DATA_WIDTH-1:0]  dout1;
+
+  // All inputs are registers
+  always @(posedge clk1)
+  begin
+    csb1_reg = csb1;
+    addr1_reg = addr1;
+    if (!csb0 && !web0 && !csb1 && (addr0 == addr1))
+         $display($time," WARNING: Writing and reading addr0=%b and addr1=%b simultaneously!",addr0,addr1);
+    #(T_HOLD) dout1 = 8'bx;
+    if ( !csb1_reg && VERBOSE )
+      $display($time," Reading %m addr1=%b dout1=%b",addr1_reg,mem[addr1_reg]);
+  end
+
+reg [DATA_WIDTH-1:0]    mem [0:RAM_DEPTH-1];
+
+  // Memory Write Block Port 0
+  // Write Operation : When web0 = 0, csb0 = 0
+  always @ (negedge clk0)
+  begin : MEM_WRITE0
+    if ( !csb0_reg && !web0_reg ) begin
+        if (wmask0_reg[0])
+                mem[addr0_reg][7:0] = din0_reg[7:0];
+    end
+  end
+
+  // Memory Read Block Port 0
+  // Read Operation : When web0 = 1, csb0 = 0
+  always @ (negedge clk0)
+  begin : MEM_READ0
+    if (!csb0_reg && web0_reg)
+       dout0 <= #(DELAY) mem[addr0_reg];
+  end
+
+  // Memory Read Block Port 1
+  // Read Operation : When web1 = 1, csb1 = 0
+  always @ (negedge clk1)
+  begin : MEM_READ1
+    if (!csb1_reg)
+       dout1 <= #(DELAY) mem[addr1_reg];
+  end
+
+endmodule

--- a/hardware/vivado/basys3/basys3.xpr
+++ b/hardware/vivado/basys3/basys3.xpr
@@ -88,6 +88,13 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../../build/sky130_sram_1kbyte_1rw1r_8x1024_8.v">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../../vhdl/patmos_ocmem.vhdl">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>


### PR DESCRIPTION
Adds the verilog model of a 1kiB dual port SRAM. In Chisel the model is used in the `SRAM` module which combines as many SRAM's as needed to create a memory of arbitrary width and depth.

In the `MemBlock` module, commonly used throughout the patmos design as a basic memory building block, a conditional block is added to select between using the normal `SyncReadMem` or `SRAM`.

The verilog file of the SRAM model was added to the quartus project file for the DE2-115 and to the vivado project for the basys3.