### PR TITLE
Fix null stack cache

### DIFF
--- a/hardware/src/main/scala/stackcache/NullStackCache.scala
+++ b/hardware/src/main/scala/stackcache/NullStackCache.scala
@@ -81,10 +81,12 @@ class NullStackCache() extends Module {
 
   // translate write requests
   val wc = Module(new WriteNoBuffer())
-  wc.io.readMaster <> nc.io.slave
+  wc.io.readMaster.M := nc.io.slave.M
+  nc.io.slave.S := wc.io.readMaster.S
   wc.io.writeMaster.M := io.fromCPU.M
   wc.io.writeMaster.M.Addr := io.fromCPU.M.Addr + stackTopReg
-  wc.io.slave <> io.toMemory
+  io.toMemory.M := wc.io.slave.M
+  wc.io.slave.S := io.toMemory.S
 
   // construct response
   io.fromCPU.S.Data := nc.io.master.S.Data


### PR DESCRIPTION
The bulk assignment operator semantics have changed from chisel2 to chisel3. Both sides of the assignment need to have the same type, not just the same fields. The assignments were instead done explicitly.