### PR TITLE
PTPAsssist: RTC timestamp extension to 64-bit second

### DIFF
--- a/c/ethlib/ptp1588.h
+++ b/c/ethlib/ptp1588.h
@@ -18,20 +18,18 @@
 
 #define PTP_RXCHAN_TIMESTAMP_NS(base)     *((volatile _SPM unsigned int *) (base+0xE000))
 #define PTP_RXCHAN_TIMESTAMP_SEC(base)    *((volatile _SPM unsigned int *) (base+0xE004))
-#define PTP_RXCHAN_STATUS(base)           *((volatile _SPM unsigned int *) (base+0xE008))
-#define PTP_RXCHAN_DSTMACLO_FILTER(base)    *((volatile _SPM unsigned int *) (base+0xE00C))
-#define PTP_RXCHAN_DSTMACHI_FILTER(base)    *((volatile _SPM unsigned int *) (base+0xE010))
+#define PTP_RXCHAN_TIMESTAMP_SEC_LO(base) *((volatile _SPM unsigned int *) (base+0xE004))
+#define PTP_RXCHAN_TIMESTAMP_SEC_HI(base) *((volatile _SPM unsigned int *) (base+0xE008))
+#define PTP_RXCHAN_STATUS(base)           *((volatile _SPM unsigned int *) (base+0xE00C))
 
 #define PTP_TXCHAN_TIMESTAMP_NS(base)     *((volatile _SPM unsigned int *) (base+0xE400))
 #define PTP_TXCHAN_TIMESTAMP_SEC(base)    *((volatile _SPM unsigned int *) (base+0xE404))
-#define PTP_TXCHAN_STATUS(base)           *((volatile _SPM unsigned int *) (base+0xE408))
-#define PTP_TXCHAN_DSTMACLO_FILTER(base)    *((volatile _SPM unsigned int *) (base+0xE40C))
-#define PTP_TXCHAN_DSTMACHI_FILTER(base)    *((volatile _SPM unsigned int *) (base+0xE410))
+#define PTP_TXCHAN_TIMESTAMP_SEC_LO(base) *((volatile _SPM unsigned int *) (base+0xE404))
+#define PTP_TXCHAN_TIMESTAMP_SEC_HI(base) *((volatile _SPM unsigned int *) (base+0xE408))
+#define PTP_TXCHAN_STATUS(base)           *((volatile _SPM unsigned int *) (base+0xE40C))
 
 #define RTC_TIME_NS(base)       *((volatile _SPM unsigned int *) (base+0xE800))
 #define RTC_TIME_SEC(base)      *((volatile _SPM unsigned int *) (base+0xE804))
-#define RTC_PERIOD_LO(base)     *((volatile _SPM unsigned int *) (base+0xE810))
-#define RTC_PERIOD_HI(base)     *((volatile _SPM unsigned int *) (base+0xE814))
 #define RTC_ADJUST_OFFSET(base) *((volatile _SPM signed int *)   (base+0xE820))
 
 //Protocol types

--- a/hardware/config/altde2-all.xml
+++ b/hardware/config/altde2-all.xml
@@ -53,7 +53,7 @@
         <param name="extAddrWidth" value="16" />
         <param name="dataWidth" value="32" />
         <param name="withPTP" value="true" />
-        <param name="secondsWidth" value="32"/>
+        <param name="secondsWidth" value="64"/>
         <param name="nanoWidth" value="32"/>
         <param name="ppsDuration" value="1000"/>
       </params>

--- a/hardware/src/main/scala/ptp1588assist/MIITimestampUnit.scala
+++ b/hardware/src/main/scala/ptp1588assist/MIITimestampUnit.scala
@@ -264,10 +264,13 @@ class MIITimestampUnit(timestampWidth: Int) extends Module {
         dataReg := rtcTimestampReg(DATA_WIDTH - 1, 0)
       }
       is(0x04.U) {
-        dataReg := rtcTimestampReg(timestampWidth - 1, DATA_WIDTH)
+        dataReg := rtcTimestampReg(2*DATA_WIDTH - 1, DATA_WIDTH)
       }
       is(0x08.U) {
-        dataReg := timestampAvailReg // Cat(validPTPReg, ptpMsgTypeReg)
+        dataReg := rtcTimestampReg(3*DATA_WIDTH  - 1, 2*DATA_WIDTH)
+      }
+      is(0x0C.U) {
+        dataReg := timestampAvailReg
       }
     }
   }
@@ -275,7 +278,7 @@ class MIITimestampUnit(timestampWidth: Int) extends Module {
   // Write response
   when(masterReg.Cmd === OcpCmd.WR) {
     switch(masterReg.Addr(4, 0)){
-      is(0x08.U){
+      is(0x0C.U){
         respReg := OcpResp.DVA
         timestampAvailReg := false.B
       }

--- a/hardware/src/main/scala/ptp1588assist/RTC.scala
+++ b/hardware/src/main/scala/ptp1588assist/RTC.scala
@@ -20,7 +20,6 @@ import patmos.Constants._
    val MICRO_IN_NANO = 1000
    val HUNDRED_NANO = 100
    val FIFTY_NANO = 50
-   val PPS_DURATION = 2 
    val PPS_DURATION = 2 * max(ppsDuration, 10) * MICRO_IN_NANO //should be between 10us to 500ms enough for a microcontroller to sample it (http://digitalsubstation.com/en/2016/11/08/white-paper-on-implementing-ptp-in-substations/)
 
    println("--RTC instantiated @ " + clockFreq / 1000000 + " MHz with a PPS pulse width= " + ppsDuration + "us")


### PR DESCRIPTION
An extension for the PTP RTC to be conform to standard of having an at least 48bit wide second's timestamp